### PR TITLE
Mockable controller context

### DIFF
--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -66,6 +66,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Testing", "src\EvoSC.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsModule.Tests", "tests\Modules\MapsModule.Tests\MapsModule.Tests.csproj", "{42628040-A753-48AC-A1B8-0FB90D2BD278}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetName.Tests", "tests\Modules\SetName.Tests\SetName.Tests.csproj", "{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -182,6 +184,10 @@ Global
 		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -211,5 +217,6 @@ Global
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{BA828B35-E9B7-4F18-B139-7F000B267D4C} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{42628040-A753-48AC-A1B8-0FB90D2BD278} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
+		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 	EndGlobalSection
 EndGlobal

--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -68,6 +68,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsModule.Tests", "tests\M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetName.Tests", "tests\Modules\SetName.Tests\SetName.Tests.csproj", "{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Testing.Tests", "tests\EvoSC.Testing.Tests\EvoSC.Testing.Tests.csproj", "{3BD1A79F-D464-4103-81FD-21E88E5B08A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -188,6 +190,10 @@ Global
 		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BD1A79F-D464-4103-81FD-21E88E5B08A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BD1A79F-D464-4103-81FD-21E88E5B08A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BD1A79F-D464-4103-81FD-21E88E5B08A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BD1A79F-D464-4103-81FD-21E88E5B08A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -218,5 +224,6 @@ Global
 		{BA828B35-E9B7-4F18-B139-7F000B267D4C} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{42628040-A753-48AC-A1B8-0FB90D2BD278} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{7EECB9FB-A6B0-4C3F-95B6-8ADD86ADF8B8} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
+		{3BD1A79F-D464-4103-81FD-21E88E5B08A3} = {46D790A2-EA9B-44A0-ABD2-A2A2CDC670D4}
 	EndGlobalSection
 EndGlobal

--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -60,6 +60,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrentMapModule", "src\Mod
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrentMapModule.Tests", "tests\Modules\CurrentMapModule.Tests\CurrentMapModule.Tests.csproj", "{B684B864-31BF-407E-9ED9-A95D32BC4FE2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Player.Tests", "tests\Modules\Player.Tests\Player.Tests.csproj", "{BA828B35-E9B7-4F18-B139-7F000B267D4C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Testing", "src\EvoSC.Testing\EvoSC.Testing.csproj", "{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -163,7 +167,15 @@ Global
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {B684B864-31BF-407E-9ED9-A95D32BC4FE2}.Release|Any CPU.Build.0 = Release|Any CPU
+								{B684B864-31BF-407E-9ED9-A95D32BC4FE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA828B35-E9B7-4F18-B139-7F000B267D4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA828B35-E9B7-4F18-B139-7F000B267D4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA828B35-E9B7-4F18-B139-7F000B267D4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA828B35-E9B7-4F18-B139-7F000B267D4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,5 +203,6 @@ Global
 		{5263B4FD-E1EB-4286-90E8-C02107C195D8} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{75867550-1DE2-4FBB-9FC1-BA840984AF49} = {DC47658A-F421-4BA4-B617-090A7DFB3900}
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
+		{BA828B35-E9B7-4F18-B139-7F000B267D4C} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 	EndGlobalSection
 EndGlobal

--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Player.Tests", "tests\Modul
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Testing", "src\EvoSC.Testing\EvoSC.Testing.csproj", "{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsModule.Tests", "tests\Modules\MapsModule.Tests\MapsModule.Tests.csproj", "{42628040-A753-48AC-A1B8-0FB90D2BD278}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +178,10 @@ Global
 		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB5A943B-CE07-48F4-BCE3-04BE895F46AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42628040-A753-48AC-A1B8-0FB90D2BD278}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -204,5 +210,6 @@ Global
 		{75867550-1DE2-4FBB-9FC1-BA840984AF49} = {DC47658A-F421-4BA4-B617-090A7DFB3900}
 		{B684B864-31BF-407E-9ED9-A95D32BC4FE2} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 		{BA828B35-E9B7-4F18-B139-7F000B267D4C} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
+		{42628040-A753-48AC-A1B8-0FB90D2BD278} = {6D75D6A2-6ECD-4DE4-96C5-CAD7D134407A}
 	EndGlobalSection
 EndGlobal

--- a/src/EvoSC.Commands/CommandInteractionContext.cs
+++ b/src/EvoSC.Commands/CommandInteractionContext.cs
@@ -5,11 +5,8 @@ using EvoSC.Common.Interfaces.Models;
 
 namespace EvoSC.Commands;
 
-public class CommandInteractionContext : PlayerInteractionContext
+public class CommandInteractionContext : PlayerInteractionContext, ICommandInteractionContext
 {
-    /// <summary>
-    /// The command that was executed in this context.
-    /// </summary>
     public required IChatCommand CommandExecuted { get; init; }
     
     public CommandInteractionContext(IOnlinePlayer player, IControllerContext context) : base(player, context)

--- a/src/EvoSC.Commands/Interfaces/ICommandInteractionContext.cs
+++ b/src/EvoSC.Commands/Interfaces/ICommandInteractionContext.cs
@@ -1,0 +1,11 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+
+namespace EvoSC.Commands.Interfaces;
+
+public interface ICommandInteractionContext : IPlayerInteractionContext
+{
+    /// <summary>
+    /// The command that was executed in this context.
+    /// </summary>
+    public IChatCommand CommandExecuted { get; init; }
+}

--- a/src/EvoSC.Common/Controllers/Context/EventControllerContext.cs
+++ b/src/EvoSC.Common/Controllers/Context/EventControllerContext.cs
@@ -5,7 +5,7 @@ namespace EvoSC.Common.Controllers.Context;
 /// <summary>
 /// Context that contains info about the fired event.
 /// </summary>
-public class EventControllerContext : GenericControllerContext
+public class EventControllerContext : GenericControllerContext, IEventControllerContext
 {
     public EventControllerContext(IControllerContext context) : base(context.ServiceScope)
     {

--- a/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
+++ b/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
@@ -8,7 +8,7 @@ namespace EvoSC.Common.Controllers.Context;
 /// Generic context for any action within a controller. If you have multiple action types, you need to use
 /// this.
 /// </summary>
-public class GenericControllerContext : IControllerContext
+public class GenericControllerContext : IGenericControllerContext
 {
     public Scope ServiceScope { get; private set; }
     public IController Controller { get; init; }

--- a/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
+++ b/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
@@ -1,6 +1,5 @@
 ﻿using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Util.Auditing;
-using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
 namespace EvoSC.Common.Controllers.Context;

--- a/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
+++ b/src/EvoSC.Common/Controllers/Context/GenericControllerContext.cs
@@ -1,4 +1,5 @@
 ﻿using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
@@ -12,7 +13,7 @@ public class GenericControllerContext : IGenericControllerContext
 {
     public Scope ServiceScope { get; private set; }
     public IController Controller { get; init; }
-    public AuditEventBuilder AuditEvent { get; init; }
+    public IAuditEventBuilder AuditEvent { get; init; }
 
     private readonly Dictionary<string, object> _customData = new();
     public Dictionary<string, object> CustomData => _customData;

--- a/src/EvoSC.Common/Controllers/Context/PlayerInteractionContext.cs
+++ b/src/EvoSC.Common/Controllers/Context/PlayerInteractionContext.cs
@@ -7,7 +7,7 @@ namespace EvoSC.Common.Controllers.Context;
 /// Context for any action that was made by a player through one of the interaction systems. For example
 /// commands or Manialinks.
 /// </summary>
-public class PlayerInteractionContext : GenericControllerContext
+public class PlayerInteractionContext : GenericControllerContext, IPlayerInteractionContext
 {
     /// <summary>
     /// The player that executed the action.

--- a/src/EvoSC.Common/EvoSC.Common.csproj
+++ b/src/EvoSC.Common/EvoSC.Common.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="EvoSC.Common.Tests" />
+        <InternalsVisibleTo Include="EvoSC.Testing" />
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
     

--- a/src/EvoSC.Common/EvoSC.Common.csproj
+++ b/src/EvoSC.Common/EvoSC.Common.csproj
@@ -17,7 +17,7 @@
       <PackageReference Include="FluentMigrator" Version="3.3.2" />
       <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
       <PackageReference Include="GBX.NET" Version="1.1.0" />
-      <PackageReference Include="GbxRemote.Net" Version="4.0.1" />
+      <PackageReference Include="GbxRemote.Net" Version="4.1.0" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="linq2db" Version="4.4.0" />
       <PackageReference Include="linq2db.MySql" Version="4.4.0" />

--- a/src/EvoSC.Common/Interfaces/Controllers/IContextService.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IContextService.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Common.Util.Auditing;
+﻿using EvoSC.Common.Interfaces.Util.Auditing;
+using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
 namespace EvoSC.Common.Interfaces.Controllers;
@@ -25,5 +26,5 @@ public interface IContextService
     /// Begin auditing a new event.
     /// </summary>
     /// <returns></returns>
-    public AuditEventBuilder Audit();
+    public IAuditEventBuilder Audit();
 }

--- a/src/EvoSC.Common/Interfaces/Controllers/IContextService.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IContextService.cs
@@ -1,5 +1,4 @@
 ﻿using EvoSC.Common.Interfaces.Util.Auditing;
-using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
 namespace EvoSC.Common.Interfaces.Controllers;

--- a/src/EvoSC.Common/Interfaces/Controllers/IControllerContext.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IControllerContext.cs
@@ -1,6 +1,5 @@
 ﻿using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Util.Auditing;
-using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
 namespace EvoSC.Common.Interfaces.Controllers;

--- a/src/EvoSC.Common/Interfaces/Controllers/IControllerContext.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IControllerContext.cs
@@ -1,4 +1,5 @@
 ﻿using EvoSC.Common.Interfaces.Middleware;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
@@ -19,7 +20,7 @@ public interface IControllerContext : IPipelineContext
     /// <summary>
     /// The audit associated with the event of this context.
     /// </summary>
-    public AuditEventBuilder AuditEvent { get; }
+    public IAuditEventBuilder AuditEvent { get; }
     
     /// <summary>
     /// This is any data that can be set to be included with the context.

--- a/src/EvoSC.Common/Interfaces/Controllers/IEventControllerContext.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IEventControllerContext.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Common.Interfaces.Controllers;
+
+public interface IEventControllerContext : IGenericControllerContext
+{
+    
+}

--- a/src/EvoSC.Common/Interfaces/Controllers/IGenericControllerContext.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IGenericControllerContext.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Common.Interfaces.Controllers;
+
+public interface IGenericControllerContext : IControllerContext
+{
+    
+}

--- a/src/EvoSC.Common/Interfaces/Controllers/IPlayerInteractionContext.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IPlayerInteractionContext.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Models;
+
+namespace EvoSC.Common.Interfaces.Controllers;
+
+public interface IPlayerInteractionContext : IGenericControllerContext
+{
+    public IOnlinePlayer Player { get; }
+}

--- a/src/EvoSC.Common/Interfaces/IServerClient.cs
+++ b/src/EvoSC.Common/Interfaces/IServerClient.cs
@@ -1,5 +1,4 @@
 ﻿using EvoSC.Common.Interfaces.Models;
-using GbxRemoteNet;
 using GbxRemoteNet.Interfaces;
 
 namespace EvoSC.Common.Interfaces;

--- a/src/EvoSC.Common/Interfaces/IServerClient.cs
+++ b/src/EvoSC.Common/Interfaces/IServerClient.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Common.Interfaces.Models;
 using GbxRemoteNet;
+using GbxRemoteNet.Interfaces;
 
 namespace EvoSC.Common.Interfaces;
 
@@ -8,7 +9,7 @@ public interface IServerClient
     /// <summary>
     /// The GBXRemote client instance.
     /// </summary>
-    public GbxRemoteClient Remote { get; }
+    public IGbxRemoteClient Remote { get; }
     /// <summary>
     /// Whether the client is connected to the remote XMLRPC server or not.
     /// </summary>

--- a/src/EvoSC.Common/Interfaces/Services/IAuditService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IAuditService.cs
@@ -1,4 +1,5 @@
 ﻿using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Models.Audit;
 using EvoSC.Common.Util.Auditing;
 using EvoSC.Common.Util.EnumIdentifier;
@@ -24,21 +25,21 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewEvent(string eventName);
+    public IAuditEventBuilder NewEvent(string eventName);
     
     /// <summary>
     /// Begin auditing a new event.
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewEvent(Enum eventName);
+    public IAuditEventBuilder NewEvent(Enum eventName);
 
     /// <summary>
     /// Begin auditing a new successful event.
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewSuccessEvent(string eventName) =>
+    public IAuditEventBuilder NewSuccessEvent(string eventName) =>
         NewEvent(eventName).WithStatus(AuditEventStatus.Success);
 
     /// <summary>
@@ -46,7 +47,7 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewSuccessEvent(Enum eventName) =>
+    public IAuditEventBuilder NewSuccessEvent(Enum eventName) =>
         NewEvent(eventName.GetIdentifier(true)).WithStatus(AuditEventStatus.Success);
     
     /// <summary>
@@ -54,7 +55,7 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewErrorEvent(string eventName) =>
+    public IAuditEventBuilder NewErrorEvent(string eventName) =>
         NewEvent(eventName).WithStatus(AuditEventStatus.Error);
 
     /// <summary>
@@ -62,7 +63,7 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewErrorEvent(Enum eventName) =>
+    public IAuditEventBuilder NewErrorEvent(Enum eventName) =>
         NewEvent(eventName.GetIdentifier(true)).WithStatus(AuditEventStatus.Error);
     
     /// <summary>
@@ -70,7 +71,7 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewInfoEvent(string eventName) =>
+    public IAuditEventBuilder NewInfoEvent(string eventName) =>
         NewEvent(eventName).WithStatus(AuditEventStatus.Info);
 
     /// <summary>
@@ -78,6 +79,6 @@ public interface IAuditService
     /// </summary>
     /// <param name="eventName">The name of the audit.</param>
     /// <returns></returns>
-    public AuditEventBuilder NewInfoEvent(Enum eventName) =>
+    public IAuditEventBuilder NewInfoEvent(Enum eventName) =>
         NewEvent(eventName.GetIdentifier(true)).WithStatus(AuditEventStatus.Info);
 }

--- a/src/EvoSC.Common/Interfaces/Services/IAuditService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IAuditService.cs
@@ -1,7 +1,6 @@
 ﻿using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Models.Audit;
-using EvoSC.Common.Util.Auditing;
 using EvoSC.Common.Util.EnumIdentifier;
 
 namespace EvoSC.Common.Interfaces.Services;

--- a/src/EvoSC.Common/Interfaces/Util/Auditing/IAuditEventBuilder.cs
+++ b/src/EvoSC.Common/Interfaces/Util/Auditing/IAuditEventBuilder.cs
@@ -1,0 +1,135 @@
+﻿using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Models.Audit;
+
+namespace EvoSC.Common.Interfaces.Util.Auditing;
+
+public interface IAuditEventBuilder
+{
+    /// <summary>
+    /// The name of the event.
+    /// </summary>
+    public string? EventName { get; }
+
+    /// <summary>
+    /// Whether this event has been canceled.
+    /// </summary>
+    public bool IsCanceled { get; }
+
+    /// <summary>
+    /// The user that caused the event.
+    /// </summary>
+    public IPlayer? Actor { get; }
+
+    /// <summary>
+    /// The status of the audit.
+    /// </summary>
+    public AuditEventStatus Status { get; }
+
+    /// <summary>
+    /// Properties associated with the event.
+    /// </summary>
+    public dynamic? Properties { get; }
+
+    /// <summary>
+    /// Comment or description of the audit.
+    /// </summary>
+    public string EventComment { get; }
+
+    /// <summary>
+    /// Whether this audit is activated; if event name is set.
+    /// Overrides IsCanceled.
+    /// </summary>
+    public bool Activated { get; }
+
+    /// <summary>
+    /// Set the name of the event.
+    /// </summary>
+    /// <param name="eventName">The name of the event.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder WithEventName(string eventName);
+
+    /// <summary>
+    /// Set the name of the event.
+    /// </summary>
+    /// <param name="eventName">The name of the event.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder WithEventName(Enum eventName);
+
+    /// <summary>
+    /// Set the properties of this event.
+    /// </summary>
+    /// <param name="properties">The properties to set.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder HavingProperties(dynamic properties);
+
+    /// <summary>
+    /// Set the status of this audit.
+    /// </summary>
+    /// <param name="status">The status to set this audit event to.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder WithStatus(AuditEventStatus status);
+
+    /// <summary>
+    /// Set the status of this audit as successful.
+    /// </summary>
+    /// <returns></returns>
+    public IAuditEventBuilder Success();
+
+    /// <summary>
+    /// Set the status of this audit as informational.
+    /// </summary>
+    /// <returns></returns>
+    public IAuditEventBuilder Info();
+
+    /// <summary>
+    /// Set the status of this audit as error.
+    /// </summary>
+    /// <returns></returns>
+    public IAuditEventBuilder Error();
+
+    /// <summary>
+    /// Set the user that caused the event.
+    /// </summary>
+    /// <param name="actor">The user that caused the event.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder CausedBy(IPlayer actor);
+
+    /// <summary>
+    /// Set whether this event is canceled or not.
+    /// </summary>
+    /// <param name="isCancelled">If true, the audit will not be logged.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder Cancel(bool isCancelled);
+
+    /// <summary>
+    /// Cancel this audit and prevent it from being logged.
+    /// </summary>
+    /// <returns></returns>
+    public IAuditEventBuilder Cancel();
+
+    /// <summary>
+    /// Un-cancel and allow logging of this audit.
+    /// </summary>
+    /// <returns></returns>
+    public IAuditEventBuilder UnCancel();
+
+    /// <summary>
+    /// Set the comment/description of this event.
+    /// </summary>
+    /// <param name="commentString">The comment for this audit.</param>
+    /// <returns></returns>
+    public IAuditEventBuilder Comment(string commentString);
+
+    /// <summary>
+    /// Log the audit now.
+    /// </summary>
+    /// <param name="comment">The comment/description of this event.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the event name is not set.</exception>
+    public Task LogAsync(string comment);
+
+    /// <summary>
+    /// Log the audit now.
+    /// </summary>
+    /// <returns></returns>
+    public Task LogAsync();
+}

--- a/src/EvoSC.Common/Remote/ServerClient.cs
+++ b/src/EvoSC.Common/Remote/ServerClient.cs
@@ -2,20 +2,21 @@
 using EvoSC.Common.Exceptions;
 using EvoSC.Common.Interfaces;
 using GbxRemoteNet;
+using GbxRemoteNet.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Common.Remote;
 
 public partial class ServerClient : IServerClient
 {
-    private readonly GbxRemoteClient _gbxRemote;
+    private readonly IGbxRemoteClient _gbxRemote;
     private readonly IEvoScBaseConfig _config;
     private readonly ILogger<ServerClient> _logger;
     private readonly IEvoSCApplication _app;
 
     private bool _connected;
 
-    public GbxRemoteClient Remote => _gbxRemote;
+    public IGbxRemoteClient Remote => _gbxRemote;
     public bool Connected => _connected;
 
     public ServerClient(IEvoScBaseConfig config, ILogger<ServerClient> logger, IEvoSCApplication app)
@@ -110,7 +111,7 @@ public partial class ServerClient : IServerClient
 
     public async Task StopAsync(CancellationToken token)
     {
-        await _gbxRemote.ChatEnableManualRoutingAsync(false);
+        await _gbxRemote.ChatEnableManualRoutingAsync(false, false);
         await _gbxRemote.SendHideManialinkPageAsync();  //hide all manialinks on disconnect
         await _gbxRemote.DisconnectAsync();
     }

--- a/src/EvoSC.Common/Services/AuditService.cs
+++ b/src/EvoSC.Common/Services/AuditService.cs
@@ -4,6 +4,7 @@ using EvoSC.Common.Database.Models.Player;
 using EvoSC.Common.Interfaces.Database.Repository;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Models.Audit;
 using EvoSC.Common.Util.Auditing;
 using EvoSC.Common.Util.EnumIdentifier;
@@ -64,7 +65,7 @@ public class AuditService : IAuditService
         LogLogger(auditRecord);
     }
 
-    public AuditEventBuilder NewEvent(string eventName) => new(this, eventName);
+    public IAuditEventBuilder NewEvent(string eventName) => new AuditEventBuilder(this, eventName);
 
-    public AuditEventBuilder NewEvent(Enum eventName) => NewEvent(eventName.GetIdentifier(true));
+    public IAuditEventBuilder NewEvent(Enum eventName) => NewEvent(eventName.GetIdentifier(true));
 }

--- a/src/EvoSC.Common/Services/ContextService.cs
+++ b/src/EvoSC.Common/Services/ContextService.cs
@@ -1,6 +1,7 @@
 ﻿using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Util.Auditing;
 using SimpleInjector;
 
@@ -45,5 +46,5 @@ public class ContextService : IContextService
         return _context;
     }
 
-    public AuditEventBuilder Audit() => GetContext().AuditEvent;
+    public IAuditEventBuilder Audit() => GetContext().AuditEvent;
 }

--- a/src/EvoSC.Common/Util/Auditing/AuditEventBuilder.cs
+++ b/src/EvoSC.Common/Util/Auditing/AuditEventBuilder.cs
@@ -1,54 +1,23 @@
 ﻿using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Models.Audit;
 using EvoSC.Common.Util.EnumIdentifier;
 
 namespace EvoSC.Common.Util.Auditing;
 
-public class AuditEventBuilder
+public class AuditEventBuilder : IAuditEventBuilder
 {
     private readonly IAuditService _auditService;
-    
-    /// <summary>
-    /// The name of the event.
-    /// </summary>
+ 
     public string? EventName { get; private set; }
-    
-    /// <summary>
-    /// Whether this event has been canceled.
-    /// </summary>
     public bool IsCanceled { get; private set; }
-    
-    /// <summary>
-    /// The user that caused the event.
-    /// </summary>
     public IPlayer? Actor { get; private set; }
-    
-    /// <summary>
-    /// The status of the audit.
-    /// </summary>
     public AuditEventStatus Status { get; private set; }
-    
-    /// <summary>
-    /// Properties associated with the event.
-    /// </summary>
     public dynamic? Properties { get; private set; }
-    
-    /// <summary>
-    /// Comment or description of the audit.
-    /// </summary>
     public string EventComment { get; private set; }
-    
-    /// <summary>
-    /// Whether this audit is activated; if event name is set.
-    /// Overrides IsCanceled.
-    /// </summary>
     public bool Activated { get; private set; }
     
-    /// <summary>
-    /// Create a new audit builder from the audit service.
-    /// </summary>
-    /// <param name="auditService">The audit service to use.</param>
     internal AuditEventBuilder(IAuditService auditService)
     {
         _auditService = auditService;
@@ -56,11 +25,6 @@ public class AuditEventBuilder
         Cancel();
     }
     
-    /// <summary>
-    /// Create a new builder with a specific event name
-    /// </summary>
-    /// <param name="auditService">The audit service to use.</param>
-    /// <param name="eventName">The name of the event.</param>
     internal AuditEventBuilder(IAuditService auditService, string eventName)
     {
         _auditService = auditService;
@@ -69,12 +33,7 @@ public class AuditEventBuilder
         Activated = true;
     }
 
-    /// <summary>
-    /// Set the name of the event.
-    /// </summary>
-    /// <param name="eventName">The name of the event.</param>
-    /// <returns></returns>
-    public AuditEventBuilder WithEventName(string eventName)
+    public IAuditEventBuilder WithEventName(string eventName)
     {
         EventName = eventName;
         UnCancel();
@@ -82,103 +41,48 @@ public class AuditEventBuilder
         return this;
     }
 
-    /// <summary>
-    /// Set the name of the event.
-    /// </summary>
-    /// <param name="eventName">The name of the event.</param>
-    /// <returns></returns>
-    public AuditEventBuilder WithEventName(Enum eventName) => WithEventName(eventName.GetIdentifier(true));
+    public IAuditEventBuilder WithEventName(Enum eventName) => WithEventName(eventName.GetIdentifier(true));
 
-    /// <summary>
-    /// Set the properties of this event.
-    /// </summary>
-    /// <param name="properties">The properties to set.</param>
-    /// <returns></returns>
-    public AuditEventBuilder HavingProperties(dynamic properties)
+    public IAuditEventBuilder HavingProperties(dynamic properties)
     {
         Properties = properties;
         return this;
     }
     
-    /// <summary>
-    /// Set the status of this audit.
-    /// </summary>
-    /// <param name="status"></param>
-    /// <returns></returns>
-    public AuditEventBuilder WithStatus(AuditEventStatus status)
+    public IAuditEventBuilder WithStatus(AuditEventStatus status)
     {
         Status = status;
         return this;
     }
 
-    /// <summary>
-    /// Set the status of this audit as successful.
-    /// </summary>
-    /// <returns></returns>
-    public AuditEventBuilder Success() => WithStatus(AuditEventStatus.Success);
+    public IAuditEventBuilder Success() => WithStatus(AuditEventStatus.Success);
     
-    /// <summary>
-    /// Set the status of this audit as informational.
-    /// </summary>
-    /// <returns></returns>
-    public AuditEventBuilder Info() => WithStatus(AuditEventStatus.Info);
+    public IAuditEventBuilder Info() => WithStatus(AuditEventStatus.Info);
     
-    /// <summary>
-    /// Set the status of this audit as error.
-    /// </summary>
-    /// <returns></returns>
-    public AuditEventBuilder Error() => WithStatus(AuditEventStatus.Error);
+    public IAuditEventBuilder Error() => WithStatus(AuditEventStatus.Error);
 
-    /// <summary>
-    /// Set the user that caused the event.
-    /// </summary>
-    /// <param name="actor">The user that caused the event.</param>
-    /// <returns></returns>
-    public AuditEventBuilder CausedBy(IPlayer actor)
+    public IAuditEventBuilder CausedBy(IPlayer actor)
     {
         Actor = actor;
         return this;
     }
 
-    /// <summary>
-    /// Set whether this event is canceled or not.
-    /// </summary>
-    /// <param name="isCancelled">If true, the audit will not be logged.</param>
-    /// <returns></returns>
-    public AuditEventBuilder Cancel(bool isCancelled)
+    public IAuditEventBuilder Cancel(bool isCancelled)
     {
         IsCanceled = isCancelled;
         return this;
     }
     
-    /// <summary>
-    /// Cancel this audit and prevent it from being logged.
-    /// </summary>
-    /// <returns></returns>
-    public AuditEventBuilder Cancel() => Cancel(true);
+    public IAuditEventBuilder Cancel() => Cancel(true);
     
-    /// <summary>
-    /// Un-cancel and allow logging of this audit.
-    /// </summary>
-    /// <returns></returns>
-    public AuditEventBuilder UnCancel() => Cancel(false);
+    public IAuditEventBuilder UnCancel() => Cancel(false);
     
-    /// <summary>
-    /// Set the comment/description of this event.
-    /// </summary>
-    /// <param name="comment"></param>
-    /// <returns></returns>
-    public AuditEventBuilder Comment(string commentString)
+    public IAuditEventBuilder Comment(string commentString)
     {
         EventComment = commentString;
         return this;
     }
 
-    /// <summary>
-    /// Log the audit now.
-    /// </summary>
-    /// <param name="comment">The comment/description of this event.</param>
-    /// <exception cref="InvalidOperationException"></exception>
     public async Task LogAsync(string comment)
     {
         if (IsCanceled)
@@ -197,9 +101,5 @@ public class AuditEventBuilder
         Cancel();
     }
 
-    /// <summary>
-    /// Log the audit now.
-    /// </summary>
-    /// <returns></returns>
     public Task LogAsync() => LogAsync(string.IsNullOrEmpty(EventComment) ? "" : EventComment);
 }

--- a/src/EvoSC.Manialinks/Interfaces/IManialinkController.cs
+++ b/src/EvoSC.Manialinks/Interfaces/IManialinkController.cs
@@ -1,0 +1,112 @@
+﻿using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Validation;
+
+namespace EvoSC.Manialinks.Interfaces;
+
+public interface IManialinkController
+{
+    /// <summary>
+    /// The model validation result of the current context.
+    /// </summary>
+    public FormValidationResult ModelValidation { get; }
+    
+    /// <summary>
+    /// Whether the model of the current context is valid or not.
+    /// </summary>
+    public bool IsModelValid { get; }
+
+    /// <summary>
+    /// Display a manialink to all players.
+    /// </summary>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <returns></returns>
+    public Task ShowAsync(string maniaLink);
+
+    /// <summary>
+    /// Display a manialink to all players.
+    /// </summary>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <param name="data">Data to send to use with manialink template.</param>
+    /// <returns></returns>
+    public Task ShowAsync(string maniaLink, object data);
+
+    /// <summary>
+    /// Display a manialink to a player.
+    /// </summary>
+    /// <param name="player">The player to show the manialink to.</param>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <returns></returns>
+    public Task ShowAsync(IOnlinePlayer player, string maniaLink);
+
+    /// <summary>
+    /// Display a manialink to a player.
+    /// </summary>
+    /// <param name="player">The player to show the manialink to.</param>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <param name="data">Data to send to use with manialink template.</param>
+    /// <returns></returns>
+    public Task ShowAsync(IOnlinePlayer player, string maniaLink, object data);
+
+    /// <summary>
+    /// Display a manialink to a set of players.
+    /// </summary>
+    /// <param name="players">The players to show the manialink to.</param>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <returns></returns>
+    public Task ShowAsync(IEnumerable<IOnlinePlayer> players, string maniaLink);
+
+    /// <summary>
+    /// Display a manialink to a set of players.
+    /// </summary>
+    /// <param name="players">The players to show the manialink to.</param>
+    /// <param name="maniaLink">The manialink to show.</param>
+    /// <param name="data">Data to send to use with manialink template.</param>
+    /// <returns></returns>
+    public Task ShowAsync(IEnumerable<IOnlinePlayer> players, string maniaLink, object data);
+
+    /// <summary>
+    /// Show a manialink to all players which persists between player connections and will
+    /// automatically show when new players connects.
+    /// </summary>
+    /// <param name="name">The name of the manialink to show.</param>
+    /// <returns></returns>
+    public Task ShowPersistentAsync(string name);
+
+    /// <summary>
+    /// Show a manialink to all players which persists between player connections and will
+    /// automatically show when new players connects.
+    /// </summary>
+    /// <param name="name">Name of the manialink to show.</param>
+    /// <param name="data">Data to be sent to the manialink template.</param>
+    /// <returns></returns>
+    public Task ShowPersistentAsync(string name, object data);
+
+    /// <summary>
+    /// Hide a manialink for all players.
+    /// </summary>
+    /// <param name="maniaLink">The name of the manialink to hide.</param>
+    /// <returns></returns>
+    public Task HideAsync(string maniaLink);
+
+    /// <summary>
+    /// Hide a manialink from a player.
+    /// </summary>
+    /// <param name="player">The player to hide the manialink from.</param>
+    /// <param name="maniaLink">The name of the manialink to hide.</param>
+    /// <returns></returns>
+    public Task HideAsync(IOnlinePlayer player, string maniaLink);
+
+    /// <summary>
+    /// Hide a manialink from a set of players.
+    /// </summary>
+    /// <param name="players">The players to hide the manialink from.</param>
+    /// <param name="maniaLink">The name of the manialink to hide.</param>
+    /// <returns></returns>
+    public Task HideAsync(IEnumerable<IOnlinePlayer> players, string maniaLink);
+
+    /// <summary>
+    /// Validate the model of the current context.
+    /// </summary>
+    /// <returns></returns>
+    public Task<FormValidationResult> ValidateModelAsync();
+}

--- a/src/EvoSC.Manialinks/Interfaces/IManialinkInteractionContext.cs
+++ b/src/EvoSC.Manialinks/Interfaces/IManialinkInteractionContext.cs
@@ -1,0 +1,17 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Manialinks.Interfaces.Models;
+
+namespace EvoSC.Manialinks.Interfaces;
+
+public interface IManialinkInteractionContext : IPlayerInteractionContext
+{
+    /// <summary>
+    /// Information about the manialink action that occured.
+    /// </summary>
+    public IManialinkActionContext ManialinkAction { get; init; }
+
+    /// <summary>
+    /// The manialink manager service.
+    /// </summary>
+    public IManialinkManager ManialinkManager { get; init; }
+}

--- a/src/EvoSC.Manialinks/ManialinkController.cs
+++ b/src/EvoSC.Manialinks/ManialinkController.cs
@@ -10,117 +10,40 @@ using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
 
 namespace EvoSC.Manialinks;
 
-public class ManialinkController : EvoScController<IManialinkInteractionContext>
+public class ManialinkController : EvoScController<IManialinkInteractionContext>, IManialinkController
 {
-    /// <summary>
-    /// The model validation result of the current context.
-    /// </summary>
-    protected FormValidationResult ModelValidation { get; } = new();
+    public FormValidationResult ModelValidation { get; } = new();
     
-    /// <summary>
-    /// Whether the model of the current context is valid or not.
-    /// </summary>
-    protected bool IsModelValid => ModelValidation?.IsValid ?? false;
+    public bool IsModelValid => ModelValidation?.IsValid ?? false;
     
-    /// <summary>
-    /// Display a manialink to all players.
-    /// </summary>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <returns></returns>
     public Task ShowAsync(string maniaLink) => Context.ManialinkManager.SendManialinkAsync(maniaLink, PrepareManialinkData(new object()));
     
-    /// <summary>
-    /// Display a manialink to all players.
-    /// </summary>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <param name="data">Data to send to use with manialink template.</param>
-    /// <returns></returns>
     public Task ShowAsync(string maniaLink, object data) => Context.ManialinkManager.SendManialinkAsync(maniaLink, PrepareManialinkData(data));
 
-    /// <summary>
-    /// Display a manialink to a player.
-    /// </summary>
-    /// <param name="player">The player to show the manialink to.</param>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <returns></returns>
     public Task ShowAsync(IOnlinePlayer player, string maniaLink) =>
         Context.ManialinkManager.SendManialinkAsync(player, maniaLink, PrepareManialinkData(new object()));
     
-    /// <summary>
-    /// Display a manialink to a player.
-    /// </summary>
-    /// <param name="player">The player to show the manialink to.</param>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <param name="data">Data to send to use with manialink template.</param>
-    /// <returns></returns>
     public Task ShowAsync(IOnlinePlayer player, string maniaLink, object data) =>
         Context.ManialinkManager.SendManialinkAsync(player, maniaLink, PrepareManialinkData(data));
     
-    /// <summary>
-    /// Display a manialink to a set of players.
-    /// </summary>
-    /// <param name="players">The players to show the manialink to.</param>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <returns></returns>
     public Task ShowAsync(IEnumerable<IOnlinePlayer> players, string maniaLink) =>
         Context.ManialinkManager.SendManialinkAsync(players, maniaLink, PrepareManialinkData(new object()));
 
-    /// <summary>
-    /// Display a manialink to a set of players.
-    /// </summary>
-    /// <param name="players">The players to show the manialink to.</param>
-    /// <param name="maniaLink">The manialink to show.</param>
-    /// <param name="data">Data to send to use with manialink template.</param>
-    /// <returns></returns>
     public Task ShowAsync(IEnumerable<IOnlinePlayer> players, string maniaLink, object data) =>
         Context.ManialinkManager.SendManialinkAsync(players, maniaLink, PrepareManialinkData(data));
 
-    /// <summary>
-    /// Show a manialink to all players which persists between player connections and will
-    /// automatically show when new players connects.
-    /// </summary>
-    /// <param name="name">The name of the manialink to show.</param>
-    /// <returns></returns>
     public Task ShowPersistentAsync(string name) => Context.ManialinkManager.SendPersistentManialinkAsync(name, PrepareManialinkData(new object()));
     
-    /// <summary>
-    /// Show a manialink to all players which persists between player connections and will
-    /// automatically show when new players connects.
-    /// </summary>
-    /// <param name="name">Name of the manialink to show.</param>
-    /// <param name="data">Data to be sent to the manialink template.</param>
-    /// <returns></returns>
     public Task ShowPersistentAsync(string name, object data) => Context.ManialinkManager.SendPersistentManialinkAsync(name, PrepareManialinkData(data));
     
-    /// <summary>
-    /// Hide a manialink for all players.
-    /// </summary>
-    /// <param name="maniaLink">The name of the manialink to hide.</param>
-    /// <returns></returns>
     public Task HideAsync(string maniaLink) => Context.ManialinkManager.HideManialinkAsync(maniaLink);
 
-    /// <summary>
-    /// Hide a manialink from a player.
-    /// </summary>
-    /// <param name="player">The player to hide the manialink from.</param>
-    /// <param name="maniaLink">The name of the manialink to hide.</param>
-    /// <returns></returns>
     public Task HideAsync(IOnlinePlayer player, string maniaLink) =>
         Context.ManialinkManager.HideManialinkAsync(player, maniaLink);
 
-    /// <summary>
-    /// Hide a manialink from a set of players.
-    /// </summary>
-    /// <param name="players">The players to hide the manialink from.</param>
-    /// <param name="maniaLink">The name of the manialink to hide.</param>
-    /// <returns></returns>
     public Task HideAsync(IEnumerable<IOnlinePlayer> players, string maniaLink) =>
         Context.ManialinkManager.HideManialinkAsync(players, maniaLink);
 
-    /// <summary>
-    /// Validate the model of the current context.
-    /// </summary>
-    /// <returns></returns>
     public Task<FormValidationResult> ValidateModelAsync() => ValidateModelInternalAsync();
 
     /// <summary>

--- a/src/EvoSC.Manialinks/ManialinkController.cs
+++ b/src/EvoSC.Manialinks/ManialinkController.cs
@@ -3,13 +3,14 @@ using System.Dynamic;
 using System.Reflection;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Interfaces;
 using EvoSC.Manialinks.Interfaces.Validation;
 using EvoSC.Manialinks.Validation;
 using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
 
 namespace EvoSC.Manialinks;
 
-public class ManialinkController : EvoScController<ManialinkInteractionContext>
+public class ManialinkController : EvoScController<IManialinkInteractionContext>
 {
     /// <summary>
     /// The model validation result of the current context.

--- a/src/EvoSC.Manialinks/ManialinkInteractionContext.cs
+++ b/src/EvoSC.Manialinks/ManialinkInteractionContext.cs
@@ -6,16 +6,9 @@ using EvoSC.Manialinks.Interfaces.Models;
 
 namespace EvoSC.Manialinks;
 
-public class ManialinkInteractionContext : PlayerInteractionContext
+public class ManialinkInteractionContext : PlayerInteractionContext, IManialinkInteractionContext
 {
-    /// <summary>
-    /// Information about the manialink action that occured.
-    /// </summary>
     public required IManialinkActionContext ManialinkAction { get; init; }
-    
-    /// <summary>
-    /// The manialink manager service.
-    /// </summary>
     public required IManialinkManager ManialinkManager { get; init; }
     
     public ManialinkInteractionContext(IOnlinePlayer player, IControllerContext context) : base(player, context)

--- a/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
@@ -8,6 +8,11 @@ namespace EvoSC.Testing.Controllers;
 public class CommandInteractionControllerTestBase<TController> : ControllerMock<TController, ICommandInteractionContext>
     where TController : class, IController
 {
+    /// <summary>
+    /// Initialize this controller mock.
+    /// </summary>
+    /// <param name="actor">The player that triggered the command.</param>
+    /// <param name="services">Services for the controller. Can be Mock objects or plain objects.</param>
     protected void InitMock(IOnlinePlayer actor, params object[] services)
     {
         base.InitMock(services);

--- a/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
@@ -1,0 +1,17 @@
+﻿using EvoSC.Commands.Interfaces;
+using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Models;
+using Moq;
+
+namespace EvoSC.Testing.Controllers;
+
+public class CommandInteractionControllerTestBase<TController> : ControllerMock<TController, ICommandInteractionContext>
+    where TController : class, IController
+{
+    protected void InitMock(IOnlinePlayer actor, params Mock[] services)
+    {
+        base.InitMock(services);
+        this.SetupMock(actor);
+    }
+}
+

--- a/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/CommandInteractionControllerTestBase.cs
@@ -8,7 +8,7 @@ namespace EvoSC.Testing.Controllers;
 public class CommandInteractionControllerTestBase<TController> : ControllerMock<TController, ICommandInteractionContext>
     where TController : class, IController
 {
-    protected void InitMock(IOnlinePlayer actor, params Mock[] services)
+    protected void InitMock(IOnlinePlayer actor, params object[] services)
     {
         base.InitMock(services);
         this.SetupMock(actor);

--- a/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Util.Auditing;
 using Moq;
 
@@ -10,23 +11,23 @@ public class ControllerContextMock<TContext> where TContext : class, IController
     private Mock<IContextService> _contextService;
     private Mock<TContext> _context;
     private Mock<IAuditService> _auditService;
-    private AuditEventBuilder _auditEventBuilder;
+    private Mock<IAuditEventBuilder> _auditEventBuilder;
     
     public Mock<TContext> Context => _context;
     public Mock<IAuditService> AuditService => _auditService;
     public Mock<IContextService> ContextService => _contextService;
+    public Mock<IAuditEventBuilder> AuditEventBuilder => _auditEventBuilder;
 
     public ControllerContextMock()
     {
         _auditService = new Mock<IAuditService>();
-        
-        _auditEventBuilder = new AuditEventBuilder(_auditService.Object);
+        _auditEventBuilder = Mocking.NewAuditEventBuilderMock();
         
         _context = new Mock<TContext>();
-        _context.Setup(c => c.AuditEvent).Returns(_auditEventBuilder);
+        _context.Setup(c => c.AuditEvent).Returns(_auditEventBuilder.Object);
 
         _contextService = new Mock<IContextService>();
         _contextService.Setup(m => m.GetContext()).Returns(_context.Object);
-        _contextService.Setup(m => m.Audit()).Returns(_auditEventBuilder);
+        _contextService.Setup(m => m.Audit()).Returns(_auditEventBuilder.Object);
     }
 }

--- a/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
@@ -1,0 +1,32 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Util.Auditing;
+using Moq;
+
+namespace EvoSC.Testing.Controllers;
+
+public class ControllerContextMock<TContext> where TContext : class, IControllerContext
+{
+    private Mock<IContextService> _contextService;
+    private Mock<TContext> _context;
+    private Mock<IAuditService> _auditService;
+    private AuditEventBuilder _auditEventBuilder;
+    
+    public Mock<TContext> Context => _context;
+    public Mock<IAuditService> AuditService => _auditService;
+    public Mock<IContextService> ContextService => _contextService;
+
+    public ControllerContextMock()
+    {
+        _auditService = new Mock<IAuditService>();
+        
+        _auditEventBuilder = new AuditEventBuilder(_auditService.Object);
+        
+        _context = new Mock<TContext>();
+        _context.Setup(c => c.AuditEvent).Returns(_auditEventBuilder);
+
+        _contextService = new Mock<IContextService>();
+        _contextService.Setup(m => m.GetContext()).Returns(_context.Object);
+        _contextService.Setup(m => m.Audit()).Returns(_auditEventBuilder);
+    }
+}

--- a/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerContextMock.cs
@@ -13,9 +13,24 @@ public class ControllerContextMock<TContext> where TContext : class, IController
     private Mock<IAuditService> _auditService;
     private Mock<IAuditEventBuilder> _auditEventBuilder;
     
+    /// <summary>
+    /// The context mock.
+    /// </summary>
     public Mock<TContext> Context => _context;
-    public Mock<IAuditService> AuditService => _auditService;
+    
+    /// <summary>
+    /// The context service mock.
+    /// </summary>
     public Mock<IContextService> ContextService => _contextService;
+    
+    /// <summary>
+    /// The audit service mock.
+    /// </summary>
+    public Mock<IAuditService> AuditService => _auditService;
+
+    /// <summary>
+    /// The audit event builder mock.
+    /// </summary>
     public Mock<IAuditEventBuilder> AuditEventBuilder => _auditEventBuilder;
 
     public ControllerContextMock()
@@ -26,8 +41,6 @@ public class ControllerContextMock<TContext> where TContext : class, IController
         _context = new Mock<TContext>();
         _context.Setup(c => c.AuditEvent).Returns(_auditEventBuilder.Object);
 
-        _contextService = new Mock<IContextService>();
-        _contextService.Setup(m => m.GetContext()).Returns(_context.Object);
-        _contextService.Setup(m => m.Audit()).Returns(_auditEventBuilder.Object);
+        _contextService = Mocking.NewContextServiceMock(Context.Object, null);
     }
 }

--- a/src/EvoSC.Testing/Controllers/ControllerMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerMock.cs
@@ -11,7 +11,7 @@ public class ControllerMock<TController, TContext> : ControllerContextMock<TCont
 
     public TController Controller => _controller;
 
-    public virtual void InitMock(params Mock[] services)
+    public virtual void InitMock(params object[] services)
     {
         _controller = Mocking.NewControllerMock<TController, TContext>(this, services);
     }

--- a/src/EvoSC.Testing/Controllers/ControllerMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerMock.cs
@@ -1,0 +1,18 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+using Moq;
+
+namespace EvoSC.Testing.Controllers;
+
+public class ControllerMock<TController, TContext> : ControllerContextMock<TContext>
+    where TController : class, IController
+    where TContext : class, IControllerContext
+{
+    private TController _controller;
+
+    public TController Controller => _controller;
+
+    public virtual void InitMock(params Mock[] services)
+    {
+        _controller = Mocking.NewControllerMock<TController, TContext>(this, services);
+    }
+}

--- a/src/EvoSC.Testing/Controllers/ControllerMock.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerMock.cs
@@ -9,8 +9,15 @@ public class ControllerMock<TController, TContext> : ControllerContextMock<TCont
 {
     private TController _controller;
 
+    /// <summary>
+    /// The instance of the mocked controller.
+    /// </summary>
     public TController Controller => _controller;
 
+    /// <summary>
+    /// Initialize this controller mock.
+    /// </summary>
+    /// <param name="services">Services for the controller. Can be Mock objects or plain objects.</param>
     public virtual void InitMock(params object[] services)
     {
         _controller = Mocking.NewControllerMock<TController, TContext>(this, services);

--- a/src/EvoSC.Testing/Controllers/ControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/ControllerTestBase.cs
@@ -1,0 +1,13 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+
+namespace EvoSC.Testing.Controllers;
+
+public class ControllerTestBase<TController, TContext> : ControllerContextMock<TContext>
+    where TController : class, IController
+    where TContext : class, IControllerContext
+{
+    public ControllerTestBase()
+    {
+        
+    }
+}

--- a/src/EvoSC.Testing/Controllers/EventControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/EventControllerTestBase.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+
+namespace EvoSC.Testing.Controllers;
+
+public class EventControllerTestBase<TController> : ControllerMock<TController, IEventControllerContext>
+    where TController : class, IController
+{
+}

--- a/src/EvoSC.Testing/Controllers/ManialinkControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/ManialinkControllerTestBase.cs
@@ -11,8 +11,17 @@ public class ManialinkControllerTestBase<TController> : ControllerMock<TControll
 {
     private Mock<IManialinkManager> _mlManager = new();
 
+    /// <summary>
+    /// The manialink manager mock used for this mock.
+    /// </summary>
     public Mock<IManialinkManager> ManialinkManager => _mlManager;
     
+    /// <summary>
+    /// Initialize this controller mock.
+    /// </summary>
+    /// <param name="actor">The player that triggered the command.</param>
+    /// <param name="actionContext">The manialink action context for this mock.</param>
+    /// <param name="services">Services for the controller. Can be Mock objects or plain objects.</param>
     protected void InitMock(IOnlinePlayer actor, IManialinkActionContext actionContext, params object[] services)
     {
         base.InitMock(services);

--- a/src/EvoSC.Testing/Controllers/ManialinkControllerTestBase.cs
+++ b/src/EvoSC.Testing/Controllers/ManialinkControllerTestBase.cs
@@ -1,0 +1,21 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Interfaces;
+using EvoSC.Manialinks.Interfaces.Models;
+using Moq;
+
+namespace EvoSC.Testing.Controllers;
+
+public class ManialinkControllerTestBase<TController> : ControllerMock<TController, IManialinkInteractionContext>
+    where TController : class, IController
+{
+    private Mock<IManialinkManager> _mlManager = new();
+
+    public Mock<IManialinkManager> ManialinkManager => _mlManager;
+    
+    protected void InitMock(IOnlinePlayer actor, IManialinkActionContext actionContext, params object[] services)
+    {
+        base.InitMock(services);
+        this.SetupMock(actor, actionContext, _mlManager.Object);
+    }
+}

--- a/src/EvoSC.Testing/EvoSC.Testing.csproj
+++ b/src/EvoSC.Testing/EvoSC.Testing.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Moq" Version="4.18.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EvoSC.Commands\EvoSC.Commands.csproj" />
+      <ProjectReference Include="..\EvoSC.Common\EvoSC.Common.csproj" />
+      <ProjectReference Include="..\EvoSC.Manialinks\EvoSC.Manialinks.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/EvoSC.Testing/Mocking.cs
+++ b/src/EvoSC.Testing/Mocking.cs
@@ -1,7 +1,4 @@
-﻿using System.Dynamic;
-using System.Globalization;
-using System.Resources;
-using EvoSC.Commands;
+﻿using System.Globalization;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Config.Models;
 using EvoSC.Common.Interfaces;
@@ -11,26 +8,33 @@ using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Localization;
 using EvoSC.Common.Models.Audit;
-using EvoSC.Common.Util.Auditing;
-using EvoSC.Manialinks;
 using EvoSC.Manialinks.Interfaces;
 using EvoSC.Manialinks.Interfaces.Models;
 using EvoSC.Testing.Controllers;
 using GbxRemoteNet.Interfaces;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Moq;
-using Org.BouncyCastle.Crypto.Tls;
 
 namespace EvoSC.Testing;
 
 public static class Mocking
 {
+    /// <summary>
+    /// Create a new controller context mock that is set up with audit and context service mocks.
+    /// </summary>
+    /// <typeparam name="TContext">The context type to mock.</typeparam>
+    /// <returns></returns>
     public static ControllerContextMock<TContext> NewControllerContextMock<TContext>()
         where TContext : class, IControllerContext
     {
         return new ControllerContextMock<TContext>();
     }
 
+    /// <summary>
+    /// Set up a player interaction context mock.
+    /// </summary>
+    /// <param name="mock">The mock to set up.</param>
+    /// <param name="actor">The mocked actor that triggered this action.</param>
+    /// <returns></returns>
     public static ControllerContextMock<IPlayerInteractionContext> SetupMock(
         this ControllerContextMock<IPlayerInteractionContext> mock, IOnlinePlayer actor)
     {
@@ -40,10 +44,21 @@ public static class Mocking
         return mock;
     }
 
+    /// <summary>
+    /// Create a new player interaction context mock.
+    /// </summary>
+    /// <param name="actor">The mocked actor that triggered this action.</param>
+    /// <returns></returns>
     public static ControllerContextMock<IPlayerInteractionContext>
         NewPlayerInteractionContextMock(IOnlinePlayer actor) =>
         new ControllerContextMock<IPlayerInteractionContext>().SetupMock(actor);
 
+    /// <summary>
+    /// Set up a command interaction context mock.
+    /// </summary>
+    /// <param name="mock">The mock to set up.</param>
+    /// <param name="actor">The mocked actor that triggered this command.</param>
+    /// <returns></returns>
     public static ControllerContextMock<ICommandInteractionContext> SetupMock(
         this ControllerContextMock<ICommandInteractionContext> mock, IOnlinePlayer actor)
     {
@@ -53,10 +68,23 @@ public static class Mocking
         return mock;
     }
 
+    /// <summary>
+    /// Create a new command interaction context mock.
+    /// </summary>
+    /// <param name="actor">The mocked actor that triggered this command.</param>
+    /// <returns></returns>
     public static ControllerContextMock<ICommandInteractionContext>
         NewCommandInteractionContextMock(IOnlinePlayer actor) =>
         new ControllerContextMock<ICommandInteractionContext>().SetupMock(actor);
 
+    /// <summary>
+    /// Set up a new Manialink context mock.
+    /// </summary>
+    /// <param name="mock">The mock to set up.</param>
+    /// <param name="actor">The mocked actor that triggered this manialink action.</param>
+    /// <param name="actionContext">The mocked action context to use.</param>
+    /// <param name="mlManager">The mocked manialink manager to use.</param>
+    /// <returns></returns>
     public static ControllerContextMock<IManialinkInteractionContext> SetupMock(
         this ControllerContextMock<IManialinkInteractionContext> mock, IOnlinePlayer actor,
         IManialinkActionContext actionContext, IManialinkManager mlManager)
@@ -69,12 +97,28 @@ public static class Mocking
         return mock;
     }
 
+    /// <summary>
+    /// Create a new manialink context mock.
+    /// </summary>
+    /// <param name="actor">The mocked actor that triggered this manialink action.</param>
+    /// <param name="actionContext">The mocked action context to use.</param>
+    /// <param name="mlManager">The mocked manialink manager to use.</param>
+    /// <returns></returns>
     public static ControllerContextMock<IManialinkInteractionContext> NewManialinkInteractionContextMock(
         IOnlinePlayer actor, IManialinkActionContext actionContext, IManialinkManager mlManager) =>
         new ControllerContextMock<IManialinkInteractionContext>().SetupMock(actor, actionContext, mlManager);
 
-    public static TController NewControllerMock<TController,
-        TContext>(ControllerContextMock<TContext> contextMock, params object[] services)
+    /// <summary>
+    /// Create a new controller instance that will use the mocked context and services given.
+    /// </summary>
+    /// <param name="contextMock">The mocked controller context to use.</param>
+    /// <param name="services">Either mocked or plain objects of services to pass to the constructor.</param>
+    /// <typeparam name="TController">The type of the controller to create an instance for.</typeparam>
+    /// <typeparam name="TContext">The context type which the controller uses.</typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown if the controller instance cannot be created.</exception>
+    public static TController NewControllerMock<TController, TContext>(ControllerContextMock<TContext> contextMock,
+        params object[] services)
         where TController : class, IController
         where TContext : class, IControllerContext
     {
@@ -91,6 +135,13 @@ public static class Mocking
         return controller;
     }
 
+    /// <summary>
+    /// Create new individual controller mock that is not part of a test class.
+    /// </summary>
+    /// <param name="services">Mocked or plain objects of services to pass to the controller's constructor.</param>
+    /// <typeparam name="TController">The controller to instantiate.</typeparam>
+    /// <typeparam name="TContext">The context type used by the controller.</typeparam>
+    /// <returns></returns>
     public static (TController Controller, ControllerContextMock<TContext> ContextMock) NewControllerMock<TController,
         TContext>(params object[] services)
         where TController : class, IController
@@ -102,6 +153,12 @@ public static class Mocking
         return (controller, contextMock);
     }
 
+    /// <summary>
+    /// Create a new context context service mock from the given context and actor.
+    /// </summary>
+    /// <param name="context">The context which the context service will use.</param>
+    /// <param name="actor">The actor that triggered the action.</param>
+    /// <returns></returns>
     public static Mock<IContextService> NewContextServiceMock(IControllerContext context, IOnlinePlayer? actor)
     {
         var mock = new Mock<IContextService>();
@@ -117,6 +174,11 @@ public static class Mocking
         return mock;
     }
 
+    /// <summary>
+    /// Create a mocked instance of the locale manager. All localizations will return "Test_Locale_String".
+    /// </summary>
+    /// <param name="contextService">The context service to use for this localization manager.</param>
+    /// <returns></returns>
     public static Locale NewLocaleMock(IContextService contextService)
     {
         var config = new Mock<IEvoScBaseConfig>();
@@ -129,6 +191,10 @@ public static class Mocking
         return locale;
     }
 
+    /// <summary>
+    /// Create a new mock of the server client and it's GBXRemoteClient.
+    /// </summary>
+    /// <returns></returns>
     public static (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote) NewServerClientMock()
     {
         var remote = new Mock<IGbxRemoteClient>();
@@ -138,6 +204,11 @@ public static class Mocking
         return (client, remote);
     }
 
+    /// <summary>
+    /// Create a new mock of the audit event builder. It does not assign any values, but all methods
+    /// simply returns itself. Is used to verify the methods which are called for checking if auditing occured.
+    /// </summary>
+    /// <returns></returns>
     public static Mock<IAuditEventBuilder> NewAuditEventBuilderMock()
     {
         var builder = new Mock<IAuditEventBuilder>();

--- a/src/EvoSC.Testing/Mocking.cs
+++ b/src/EvoSC.Testing/Mocking.cs
@@ -59,18 +59,19 @@ public static class Mocking
 
     public static ControllerContextMock<IManialinkInteractionContext> SetupMock(
         this ControllerContextMock<IManialinkInteractionContext> mock, IOnlinePlayer actor,
-        IManialinkActionContext actionContext)
+        IManialinkActionContext actionContext, IManialinkManager mlManager)
     {
         mock.Context.Setup(c => c.Player).Returns(actor);
         mock.Context.Setup(c => c.ManialinkAction).Returns(actionContext);
+        mock.Context.Setup(m => m.ManialinkManager).Returns(mlManager);
         mock.Context.Object.AuditEvent.CausedBy(actor);
 
         return mock;
     }
 
     public static ControllerContextMock<IManialinkInteractionContext> NewManialinkInteractionContextMock(
-        IOnlinePlayer actor, IManialinkActionContext actionContext) =>
-        new ControllerContextMock<IManialinkInteractionContext>().SetupMock(actor, actionContext);
+        IOnlinePlayer actor, IManialinkActionContext actionContext, IManialinkManager mlManager) =>
+        new ControllerContextMock<IManialinkInteractionContext>().SetupMock(actor, actionContext, mlManager);
 
     public static TController NewControllerMock<TController,
         TContext>(ControllerContextMock<TContext> contextMock, params object[] services)

--- a/src/EvoSC.Testing/Mocking.cs
+++ b/src/EvoSC.Testing/Mocking.cs
@@ -4,14 +4,17 @@ using System.Resources;
 using EvoSC.Commands;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Config.Models;
+using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Localization;
 using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Localization;
 using EvoSC.Manialinks;
 using EvoSC.Manialinks.Interfaces;
 using EvoSC.Manialinks.Interfaces.Models;
 using EvoSC.Testing.Controllers;
+using GbxRemoteNet.Interfaces;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Moq;
 using Org.BouncyCastle.Crypto.Tls;
@@ -121,5 +124,14 @@ public static class Mocking
 
         var locale = new LocaleResource(localeManager.Object, contextService, config.Object);
         return locale;
+    }
+
+    public static (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote) NewServerClientMock()
+    {
+        var remote = new Mock<IGbxRemoteClient>();
+        var client = new Mock<IServerClient>();
+        client.Setup(m => m.Remote).Returns(remote.Object);
+
+        return (client, remote);
     }
 }

--- a/src/EvoSC.Testing/Mocking.cs
+++ b/src/EvoSC.Testing/Mocking.cs
@@ -10,6 +10,8 @@ using EvoSC.Common.Interfaces.Localization;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Util.Auditing;
 using EvoSC.Common.Localization;
+using EvoSC.Common.Models.Audit;
+using EvoSC.Common.Util.Auditing;
 using EvoSC.Manialinks;
 using EvoSC.Manialinks.Interfaces;
 using EvoSC.Manialinks.Interfaces.Models;
@@ -71,11 +73,11 @@ public static class Mocking
         new ControllerContextMock<IManialinkInteractionContext>().SetupMock(actor, actionContext);
 
     public static TController NewControllerMock<TController,
-        TContext>(ControllerContextMock<TContext> contextMock, params Mock[] services)
+        TContext>(ControllerContextMock<TContext> contextMock, params object[] services)
         where TController : class, IController
         where TContext : class, IControllerContext
     {
-        var ctorArgs = services.Select(s => s.Object).ToArray();
+        var ctorArgs = services.Select(s => s.GetType().IsAssignableTo(typeof(Mock)) ? ((Mock)s).Object : s).ToArray();
         var controller = Activator.CreateInstance(typeof(TController), ctorArgs) as TController;
 
         if (controller == null)
@@ -89,7 +91,7 @@ public static class Mocking
     }
 
     public static (TController Controller, ControllerContextMock<TContext> ContextMock) NewControllerMock<TController,
-        TContext>(params Mock[] services)
+        TContext>(params object[] services)
         where TController : class, IController
         where TContext : class, IControllerContext
     {
@@ -133,5 +135,25 @@ public static class Mocking
         client.Setup(m => m.Remote).Returns(remote.Object);
 
         return (client, remote);
+    }
+
+    public static Mock<IAuditEventBuilder> NewAuditEventBuilderMock()
+    {
+        var builder = new Mock<IAuditEventBuilder>();
+
+        builder.Setup(m => m.CausedBy(It.IsAny<IPlayer>())).Returns(builder.Object);
+        builder.Setup(m => m.Comment(It.IsAny<string>())).Returns(builder.Object);
+        builder.Setup(m => m.HavingProperties(It.IsAny<object>())).Returns(builder.Object);
+        builder.Setup(m => m.Cancel()).Returns(builder.Object);
+        builder.Setup(m => m.Cancel(It.IsAny<bool>())).Returns(builder.Object);
+        builder.Setup(m => m.Error()).Returns(builder.Object);
+        builder.Setup(m => m.Info()).Returns(builder.Object);
+        builder.Setup(m => m.Success()).Returns(builder.Object);
+        builder.Setup(m => m.UnCancel()).Returns(builder.Object);
+        builder.Setup(m => m.WithStatus(It.IsAny<AuditEventStatus>())).Returns(builder.Object);
+        builder.Setup(m => m.WithEventName(It.IsAny<string>())).Returns(builder.Object);
+        builder.Setup(m => m.WithEventName(It.IsAny<Enum>())).Returns(builder.Object);
+
+        return builder;
     }
 }

--- a/src/EvoSC.Testing/Mocking.cs
+++ b/src/EvoSC.Testing/Mocking.cs
@@ -1,0 +1,125 @@
+﻿using System.Dynamic;
+using System.Globalization;
+using System.Resources;
+using EvoSC.Commands;
+using EvoSC.Commands.Interfaces;
+using EvoSC.Common.Config.Models;
+using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Localization;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Localization;
+using EvoSC.Manialinks;
+using EvoSC.Manialinks.Interfaces;
+using EvoSC.Manialinks.Interfaces.Models;
+using EvoSC.Testing.Controllers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Moq;
+using Org.BouncyCastle.Crypto.Tls;
+
+namespace EvoSC.Testing;
+
+public static class Mocking
+{
+    public static ControllerContextMock<TContext> NewControllerContextMock<TContext>()
+        where TContext : class, IControllerContext
+    {
+        return new ControllerContextMock<TContext>();
+    }
+
+    public static ControllerContextMock<IPlayerInteractionContext> SetupMock(
+        this ControllerContextMock<IPlayerInteractionContext> mock, IOnlinePlayer actor)
+    {
+        mock.Context.Setup(c => c.Player).Returns(actor);
+        mock.Context.Object.AuditEvent.CausedBy(actor);
+
+        return mock;
+    }
+
+    public static ControllerContextMock<IPlayerInteractionContext>
+        NewPlayerInteractionContextMock(IOnlinePlayer actor) =>
+        new ControllerContextMock<IPlayerInteractionContext>().SetupMock(actor);
+
+    public static ControllerContextMock<ICommandInteractionContext> SetupMock(
+        this ControllerContextMock<ICommandInteractionContext> mock, IOnlinePlayer actor)
+    {
+        mock.Context.Setup(c => c.Player).Returns(actor);
+        mock.Context.Object.AuditEvent.CausedBy(actor);
+
+        return mock;
+    }
+
+    public static ControllerContextMock<ICommandInteractionContext>
+        NewCommandInteractionContextMock(IOnlinePlayer actor) =>
+        new ControllerContextMock<ICommandInteractionContext>().SetupMock(actor);
+
+    public static ControllerContextMock<IManialinkInteractionContext> SetupMock(
+        this ControllerContextMock<IManialinkInteractionContext> mock, IOnlinePlayer actor,
+        IManialinkActionContext actionContext)
+    {
+        mock.Context.Setup(c => c.Player).Returns(actor);
+        mock.Context.Setup(c => c.ManialinkAction).Returns(actionContext);
+        mock.Context.Object.AuditEvent.CausedBy(actor);
+
+        return mock;
+    }
+
+    public static ControllerContextMock<IManialinkInteractionContext> NewManialinkInteractionContextMock(
+        IOnlinePlayer actor, IManialinkActionContext actionContext) =>
+        new ControllerContextMock<IManialinkInteractionContext>().SetupMock(actor, actionContext);
+
+    public static TController NewControllerMock<TController,
+        TContext>(ControllerContextMock<TContext> contextMock, params Mock[] services)
+        where TController : class, IController
+        where TContext : class, IControllerContext
+    {
+        var ctorArgs = services.Select(s => s.Object).ToArray();
+        var controller = Activator.CreateInstance(typeof(TController), ctorArgs) as TController;
+
+        if (controller == null)
+        {
+            throw new InvalidOperationException($"Failed to create instance of controller {typeof(TController)}");
+        }
+
+        controller.SetContext(contextMock.Context.Object);
+
+        return controller;
+    }
+
+    public static (TController Controller, ControllerContextMock<TContext> ContextMock) NewControllerMock<TController,
+        TContext>(params Mock[] services)
+        where TController : class, IController
+        where TContext : class, IControllerContext
+    {
+        var contextMock = NewControllerContextMock<TContext>();
+        var controller = NewControllerMock<TController, TContext>(contextMock, services);
+
+        return (controller, contextMock);
+    }
+
+    public static Mock<IContextService> NewContextServiceMock(IControllerContext context, IOnlinePlayer? actor)
+    {
+        var mock = new Mock<IContextService>();
+        
+        mock.Setup(s => s.Audit()).Returns(context.AuditEvent);
+        mock.Setup(s => s.GetContext()).Returns(context);
+
+        if (actor != null)
+        {
+            mock.Object.Audit().CausedBy(actor);
+        }
+
+        return mock;
+    }
+
+    public static Locale NewLocaleMock(IContextService contextService)
+    {
+        var config = new Mock<IEvoScBaseConfig>();
+        config.Setup(m => m.Locale.DefaultLanguage).Returns("en");
+        var localeManager = new Mock<ILocalizationManager>();
+        localeManager.Setup(m => m.GetString(It.IsAny<CultureInfo>(), It.IsAny<string>(), It.IsAny<object[]>()))
+            .Returns("Test_Locale_String");
+
+        var locale = new LocaleResource(localeManager.Object, contextService, config.Object);
+        return locale;
+    }
+}

--- a/src/EvoSC.Testing/Verifications.cs
+++ b/src/EvoSC.Testing/Verifications.cs
@@ -5,6 +5,15 @@ namespace EvoSC.Testing;
 
 public static class Verifications
 {
+    /// <summary>
+    /// Helper method for verifying that a logging call was made.
+    /// </summary>
+    /// <param name="loggerMock"></param>
+    /// <param name="logLevel">The log level of the log.</param>
+    /// <param name="exception">Exception if present that was logged.</param>
+    /// <param name="msg">Message which was logged.</param>
+    /// <param name="times">How many times this log was called.</param>
+    /// <typeparam name="T">The type which this logger is assigned to.</typeparam>
     public static void Verify<T>(this Mock<ILogger<T>> loggerMock, LogLevel logLevel, Exception? exception, string? msg,
         Times times)
     {
@@ -24,6 +33,7 @@ public static class Verifications
         }
         else
         {
+            // duplicate code is required due to the way moq works with it's expression system
             loggerMock.Verify(m => m.Log(
                 logLevel,
                 0,
@@ -36,14 +46,5 @@ public static class Verifications
                 It.IsAny<Func<It.IsAnyType, Exception, string>>()
             ), times);
         }
-        
-
-        /* loggerMock.Verify(m => m.Log(
-            LogLevel.Trace,
-            0,
-            It.IsAny<It.IsAnyType>(),
-            ex,
-            It.IsAny<Func<It.IsAnyType, Exception, string>>()
-        ), Times.Once); */
     }
 }

--- a/src/EvoSC.Testing/Verifications.cs
+++ b/src/EvoSC.Testing/Verifications.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace EvoSC.Testing;
+
+public static class Verifications
+{
+    public static void Verify<T>(this Mock<ILogger<T>> loggerMock, LogLevel logLevel, Exception? exception, string? msg,
+        Times times)
+    {
+        if (exception == null)
+        {
+            loggerMock.Verify(m => m.Log(
+                logLevel,
+                0,
+                It.Is<It.IsAnyType>((o, type) =>
+                    msg == null || (
+                        o.ToString()!.StartsWith(msg, StringComparison.Ordinal) 
+                        &&type.Name.Equals("FormattedLogValues", StringComparison.Ordinal)
+                    )),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()
+            ), times);
+        }
+        else
+        {
+            loggerMock.Verify(m => m.Log(
+                logLevel,
+                0,
+                It.Is<It.IsAnyType>((o, type) =>
+                    msg == null || (
+                        o.ToString()!.StartsWith(msg, StringComparison.Ordinal) 
+                        &&type.Name.Equals("FormattedLogValues", StringComparison.Ordinal)
+                    )),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()
+            ), times);
+        }
+        
+
+        /* loggerMock.Verify(m => m.Log(
+            LogLevel.Trace,
+            0,
+            It.IsAny<It.IsAnyType>(),
+            ex,
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()
+        ), Times.Once); */
+    }
+}

--- a/src/Modules/CurrentMapModule/Controllers/CurrentMapController.cs
+++ b/src/Modules/CurrentMapModule/Controllers/CurrentMapController.cs
@@ -1,6 +1,5 @@
 ﻿using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
-using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;

--- a/src/Modules/CurrentMapModule/Controllers/CurrentMapController.cs
+++ b/src/Modules/CurrentMapModule/Controllers/CurrentMapController.cs
@@ -2,6 +2,7 @@
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;
 using EvoSC.Common.Remote.EventArgsModels;
 using EvoSC.Modules.Official.CurrentMapModule.Interfaces;
@@ -10,7 +11,7 @@ using GbxRemoteNet.Events;
 namespace EvoSC.Modules.Official.CurrentMapModule.Controllers;
 
 [Controller]
-public class CurrentMapController : EvoScController<EventControllerContext>
+public class CurrentMapController : EvoScController<IEventControllerContext>
 {
     private readonly ICurrentMapService _service;
 

--- a/src/Modules/ExampleModule/ExampleController.cs
+++ b/src/Modules/ExampleModule/ExampleController.cs
@@ -4,6 +4,7 @@ using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Database.Repository;
 using EvoSC.Common.Interfaces.Localization;
 using EvoSC.Common.Interfaces.Services;
@@ -17,7 +18,7 @@ using EvoSC.Manialinks.Interfaces;
 namespace EvoSC.Modules.Official.ExampleModule;
 
 [Controller]
-public class ExampleController : EvoScController<PlayerInteractionContext>
+public class ExampleController : EvoScController<IPlayerInteractionContext>
 {
     private readonly IMySettings _settings;
     private readonly IServerClient _server;

--- a/src/Modules/ExampleModule/ExampleController2.cs
+++ b/src/Modules/ExampleModule/ExampleController2.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Manialinks.Interfaces;
@@ -7,7 +8,7 @@ using EvoSC.Manialinks.Interfaces;
 namespace EvoSC.Modules.Official.ExampleModule;
 
 [Controller]
-public class ExampleController2 : EvoScController<CommandInteractionContext>
+public class ExampleController2 : EvoScController<ICommandInteractionContext>
 {
     private readonly IManialinkManager _manialinks;
     

--- a/src/Modules/ExampleModule/ExampleEventController.cs
+++ b/src/Modules/ExampleModule/ExampleEventController.cs
@@ -3,6 +3,7 @@ using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events;
 using EvoSC.Common.Events.Attributes;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Services;
 using EvoSC.Common.Remote;
 using EvoSC.Common.Remote.EventArgsModels;
@@ -14,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace EvoSC.Modules.Official.ExampleModule;
 
 [Controller]
-public class ExampleEventController : EvoScController<EventControllerContext>
+public class ExampleEventController : EvoScController<IEventControllerContext>
 {
     private readonly ILogger<ExampleEventController> _logger;
     private readonly IManialinkManager _manialinkses;

--- a/src/Modules/FastestCp/Controllers/FastestCpController.cs
+++ b/src/Modules/FastestCp/Controllers/FastestCpController.cs
@@ -2,6 +2,7 @@
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;
 using EvoSC.Common.Remote.EventArgsModels;
 using EvoSC.Modules.Official.FastestCp.Interfaces;
@@ -10,7 +11,7 @@ using GbxRemoteNet.Events;
 namespace EvoSC.Modules.Official.FastestCp.Controllers;
 
 [Controller]
-public class FastestCpController : EvoScController<EventControllerContext>
+public class FastestCpController : EvoScController<IEventControllerContext>
 {
     private readonly IFastestCpService _fastestCpService;
 

--- a/src/Modules/FastestCp/Controllers/FastestCpController.cs
+++ b/src/Modules/FastestCp/Controllers/FastestCpController.cs
@@ -1,6 +1,5 @@
 ﻿using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
-using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;

--- a/src/Modules/MapsModule/Controllers/MapsController.cs
+++ b/src/Modules/MapsModule/Controllers/MapsController.cs
@@ -1,4 +1,3 @@
-using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;

--- a/src/Modules/MapsModule/Controllers/MapsController.cs
+++ b/src/Modules/MapsModule/Controllers/MapsController.cs
@@ -1,5 +1,6 @@
 using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Interfaces;
@@ -13,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace EvoSC.Modules.Official.Maps.Controllers;
 
 [Controller]
-public class MapsController : EvoScController<CommandInteractionContext>
+public class MapsController : EvoScController<ICommandInteractionContext>
 {
     private readonly ILogger<MapsController> _logger;
     private readonly IMxMapService _mxMapService;

--- a/src/Modules/MatchManagerModule/Controllers/FlowControlCommands.cs
+++ b/src/Modules/MatchManagerModule/Controllers/FlowControlCommands.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Interfaces;
@@ -10,7 +11,7 @@ using EvoSC.Modules.Official.MatchManagerModule.Permissions;
 namespace EvoSC.Modules.Official.MatchManagerModule.Controllers;
 
 [Controller]
-public class FlowControlCommands : EvoScController<CommandInteractionContext>
+public class FlowControlCommands : EvoScController<ICommandInteractionContext>
 {
     private readonly IFlowControlService _flowControl;
     private readonly IServerClient _server;

--- a/src/Modules/MatchManagerModule/Controllers/FlowControlCommands.cs
+++ b/src/Modules/MatchManagerModule/Controllers/FlowControlCommands.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/MatchManagerModule/Controllers/MatchSettingsCommandsController.cs
+++ b/src/Modules/MatchManagerModule/Controllers/MatchSettingsCommandsController.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;

--- a/src/Modules/MatchManagerModule/Controllers/MatchSettingsCommandsController.cs
+++ b/src/Modules/MatchManagerModule/Controllers/MatchSettingsCommandsController.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Modules.Official.MatchManagerModule.Interfaces;
@@ -9,7 +10,7 @@ using EvoSC.Modules.Official.MatchManagerModule.Permissions;
 namespace EvoSC.Modules.Official.MatchManagerModule.Controllers;
 
 [Controller]
-public class MatchSettingsCommandsController : EvoScController<CommandInteractionContext>
+public class MatchSettingsCommandsController : EvoScController<ICommandInteractionContext>
 {
     private readonly IMatchManagerHandlerService _matchHandler;
 

--- a/src/Modules/ModuleManagerModule/Controllers/ModuleCommandsController.cs
+++ b/src/Modules/ModuleManagerModule/Controllers/ModuleCommandsController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Modules.Interfaces;
@@ -8,7 +9,7 @@ using EvoSC.Modules.Official.ModuleManagerModule.Interfaces;
 namespace EvoSC.Modules.Official.ModuleManagerModule.Controllers;
 
 [Controller]
-public class ModuleCommandsController : EvoScController<CommandInteractionContext>
+public class ModuleCommandsController : EvoScController<ICommandInteractionContext>
 {
     private readonly IModuleManagerService _moduleManagerService;
     

--- a/src/Modules/ModuleManagerModule/Controllers/ModuleCommandsController.cs
+++ b/src/Modules/ModuleManagerModule/Controllers/ModuleCommandsController.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/Player/Controllers/PlayerCommandsController.cs
+++ b/src/Modules/Player/Controllers/PlayerCommandsController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Interfaces.Models;
@@ -8,7 +9,7 @@ using EvoSC.Modules.Official.Player.Interfaces;
 namespace EvoSC.Modules.Official.Player.Controllers;
 
 [Controller]
-public class PlayerCommandsController : EvoScController<CommandInteractionContext>
+public class PlayerCommandsController : EvoScController<ICommandInteractionContext>
 {
     private readonly IPlayerService _players;
 

--- a/src/Modules/Player/Controllers/PlayerCommandsController.cs
+++ b/src/Modules/Player/Controllers/PlayerCommandsController.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/Player/Controllers/PlayerEventController.cs
+++ b/src/Modules/Player/Controllers/PlayerEventController.cs
@@ -1,7 +1,7 @@
 ﻿using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
-using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;
 using EvoSC.Modules.Official.Player.Interfaces;
 using GbxRemoteNet.Events;
@@ -9,7 +9,7 @@ using GbxRemoteNet.Events;
 namespace EvoSC.Modules.Official.Player.Controllers;
 
 [Controller]
-public class PlayerEventController : EvoScController<EventControllerContext>
+public class PlayerEventController : EvoScController<IEventControllerContext>
 {
     private readonly IPlayerService _playerService;
     

--- a/src/Modules/Player/Services/PlayerService.cs
+++ b/src/Modules/Player/Services/PlayerService.cs
@@ -20,8 +20,9 @@ public class PlayerService : IPlayerService
     private readonly ILogger<PlayerService> _logger;
     private readonly IContextService _context;
     private readonly dynamic _locale;
-    
-    public PlayerService(IPlayerManagerService playerManager, IServerClient server, ILogger<PlayerService> logger, IContextService context, Locale locale)
+
+    public PlayerService(IPlayerManagerService playerManager, IServerClient server, ILogger<PlayerService> logger,
+        IContextService context, Locale locale)
     {
         _playerManager = playerManager;
         _server = server;

--- a/src/Modules/Player/Services/PlayerService.cs
+++ b/src/Modules/Player/Services/PlayerService.cs
@@ -79,7 +79,7 @@ public class PlayerService : IPlayerService
         }
         else
         {
-            await _server.ErrorMessageAsync(_locale.PlayerMutingFailed);
+            await _server.ErrorMessageAsync(_locale.PlayerMutingFailed, actor);
         }
     }
 
@@ -134,13 +134,13 @@ public class PlayerService : IPlayerService
                     .HavingProperties(new {PlayerLogin = login})
                     .Comment(_locale.Audit_Unbanned);
                 
-                await _server.SuccessMessageAsync(_locale.PlayerUnbanned(login));
+                await _server.SuccessMessageAsync(_locale.PlayerLanguage.PlayerUnbanned(login), actor);
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to unban player {Login}", login);
-            await _server.ErrorMessageAsync(_locale.PlayerUnbanningFailed(login));
+            await _server.ErrorMessageAsync(_locale.PlayerLanguage.PlayerUnbanningFailed(login), actor);
         }
 
         try
@@ -152,13 +152,13 @@ public class PlayerService : IPlayerService
                     .HavingProperties(new {PlayerLogin = login})
                     .Comment(_locale.Audit_Unblacklisted);
                 
-                await _server.SuccessMessageAsync(_locale.PlayerUnblacklisted(login));
+                await _server.SuccessMessageAsync(_locale.PlayerLanguage.PlayerUnblacklisted(login), actor);
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to un-blacklist player {Login}", login);
-            await _server.ErrorMessageAsync(_locale.PlayerUnblacklistingFailed(login));
+            await _server.ErrorMessageAsync(_locale.PlayerLanguage.PlayerUnblacklistingFailed(login), actor);
         }
     }
 }

--- a/src/Modules/PlayerRecords/Controllers/CommandController.cs
+++ b/src/Modules/PlayerRecords/Controllers/CommandController.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/PlayerRecords/Controllers/CommandController.cs
+++ b/src/Modules/PlayerRecords/Controllers/CommandController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Modules.Official.PlayerRecords.Interfaces;
@@ -7,7 +8,7 @@ using EvoSC.Modules.Official.PlayerRecords.Interfaces;
 namespace EvoSC.Modules.Official.PlayerRecords.Controllers;
 
 [Controller]
-public class CommandController : EvoScController<CommandInteractionContext>
+public class CommandController : EvoScController<ICommandInteractionContext>
 {
     private readonly IPlayerRecordHandlerService _playerRecordHandler;
 

--- a/src/Modules/PlayerRecords/Controllers/PlayerEventsController.cs
+++ b/src/Modules/PlayerRecords/Controllers/PlayerEventsController.cs
@@ -1,6 +1,5 @@
 ﻿using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
-using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;

--- a/src/Modules/PlayerRecords/Controllers/PlayerEventsController.cs
+++ b/src/Modules/PlayerRecords/Controllers/PlayerEventsController.cs
@@ -2,6 +2,7 @@
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Controllers.Context;
 using EvoSC.Common.Events.Attributes;
+using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Remote;
 using EvoSC.Common.Remote.EventArgsModels;
 using EvoSC.Modules.Official.PlayerRecords.Events;
@@ -10,7 +11,7 @@ using EvoSC.Modules.Official.PlayerRecords.Interfaces;
 namespace EvoSC.Modules.Official.PlayerRecords.Controllers;
 
 [Controller]
-public class PlayerEventsController : EvoScController<EventControllerContext>
+public class PlayerEventsController : EvoScController<IEventControllerContext>
 {
     private readonly IPlayerRecordHandlerService _playerRecordHandler;
 

--- a/src/Modules/SetName/Controllers/SetNameCommandsController.cs
+++ b/src/Modules/SetName/Controllers/SetNameCommandsController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Commands;
 using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Interfaces.Localization;
@@ -8,7 +9,7 @@ using EvoSC.Manialinks.Interfaces;
 namespace EvoSC.Modules.Official.SetName.Controllers;
 
 [Controller]
-public class SetNameCommandsController : EvoScController<CommandInteractionContext>
+public class SetNameCommandsController : EvoScController<ICommandInteractionContext>
 {
     private readonly IManialinkManager _manialinks;
     private readonly dynamic _locale;

--- a/src/Modules/SetName/Controllers/SetNameCommandsController.cs
+++ b/src/Modules/SetName/Controllers/SetNameCommandsController.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/SetName/Controllers/SetNameController.cs
+++ b/src/Modules/SetName/Controllers/SetNameController.cs
@@ -30,6 +30,7 @@ public class SetNameController : ManialinkController
         await HideAsync(Context.Player, "SetName.EditName");
 
         Context.AuditEvent
+            .Success()
             .WithEventName("EditNickname")
             .HavingProperties(new {OldNickname = Context.Player.NickName, NewNickname = input.Nickname});
     }

--- a/tests/EvoSC.Testing.Tests/EvoSC.Testing.Tests.csproj
+++ b/tests/EvoSC.Testing.Tests/EvoSC.Testing.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\EvoSC.Testing\EvoSC.Testing.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/EvoSC.Testing.Tests/MockingTests.cs
+++ b/tests/EvoSC.Testing.Tests/MockingTests.cs
@@ -1,0 +1,154 @@
+using EvoSC.Commands.Interfaces;
+using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Interfaces;
+using EvoSC.Manialinks.Interfaces.Models;
+using EvoSC.Testing.Tests.TestClasses;
+using Moq;
+
+namespace EvoSC.Testing.Tests;
+
+public class MockingTests
+{
+    [Fact]
+    public void NewControllerContextMock_Returns_Correct_Mock()
+    {
+        var mock = Mocking.NewControllerContextMock<IControllerContext>();
+        
+        Assert.NotNull(mock.Context);
+        Assert.NotNull(mock.AuditEventBuilder);
+        Assert.NotNull(mock.AuditService);
+        Assert.NotNull(mock.ContextService);
+        Assert.Equal(mock.AuditEventBuilder.Object, mock.Context.Object.AuditEvent);
+        Assert.Equal(mock.Context.Object, mock.ContextService.Object.GetContext());
+        Assert.Equal(mock.AuditEventBuilder.Object, mock.ContextService.Object.Audit());
+    }
+
+    [Fact]
+    public void SetupMock_For_PlayerInteraction_Sets_Up_Correctly()
+    {
+        var mock = Mocking.NewControllerContextMock<IPlayerInteractionContext>();
+        var player = new Mock<IOnlinePlayer>();
+        mock.SetupMock(player.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+
+    [Fact]
+    public void NewPlayerInteractionContextMock_Returns_Correct_Mock()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        var mock = Mocking.NewPlayerInteractionContextMock(player.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+
+    [Fact]
+    public void SetupMock_For_CommandInteraction_Sets_Up_Correctly()
+    {
+        var mock = Mocking.NewControllerContextMock<ICommandInteractionContext>();
+        var player = new Mock<IOnlinePlayer>();
+        mock.SetupMock(player.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+    
+    [Fact]
+    public void NewCommandInteractionContextMock_Returns_Correct_Mock()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        var mock = Mocking.NewCommandInteractionContextMock(player.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+    
+    
+    [Fact]
+    public void SetupMock_For_ManialinkInteraction_Sets_Up_Correctly()
+    {
+        var mock = Mocking.NewControllerContextMock<IManialinkInteractionContext>();
+        var player = new Mock<IOnlinePlayer>();
+        var mlActionContext = new Mock<IManialinkActionContext>();
+        var mlManager = new Mock<IManialinkManager>();
+        mock.SetupMock(player.Object, mlActionContext.Object, mlManager.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        Assert.Equal(mlActionContext.Object, mock.Context.Object.ManialinkAction);
+        Assert.Equal(mlManager.Object, mock.Context.Object.ManialinkManager);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+    
+    [Fact]
+    public void NewManialinkInteractionContextMock_Returns_Correct_Mock()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        var mlActionContext = new Mock<IManialinkActionContext>();
+        var mlManager = new Mock<IManialinkManager>();
+        var mock = Mocking.NewManialinkInteractionContextMock(player.Object, mlActionContext.Object, mlManager.Object);
+        
+        Assert.Equal(player.Object, mock.Context.Object.Player);
+        Assert.Equal(mlActionContext.Object, mock.Context.Object.ManialinkAction);
+        Assert.Equal(mlManager.Object, mock.Context.Object.ManialinkManager);
+        mock.AuditEventBuilder.Verify(m => m.CausedBy(player.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task New_Controller_Mock_Returns_Mocked_Controller_Instance()
+    {
+        var contextMock = Mocking.NewControllerContextMock<IPlayerInteractionContext>();
+        var controller = Mocking.NewControllerMock<TestController, IPlayerInteractionContext>(contextMock);
+
+        await controller.DoingSomething();
+        
+        contextMock.AuditEventBuilder.Verify(m => m.Success(), Times.Once);
+    }
+
+    [Fact]
+    public async Task New_Individual_Controller_And_Context_Mocks()
+    {
+        var mock = Mocking.NewControllerMock<TestController, IPlayerInteractionContext>();
+
+        await mock.Controller.DoingSomething();
+        
+        mock.ContextMock.AuditEventBuilder.Verify(m => m.Success(), Times.Once);
+    }
+
+    [Fact]
+    public async Task New_Controller_Mock_Passes_Ctor_Services()
+    {
+        var serviceMock = new Mock<ITestService>();
+        var mock = Mocking.NewControllerMock<TestControllerWithServices, IPlayerInteractionContext>(serviceMock);
+
+        await mock.Controller.DoSomething();
+        
+        serviceMock.Verify(m => m.DoSomethingElse(), Times.Once);
+    }
+
+    [Fact]
+    public void NewContextServiceMock_Sets_Up_Correctly()
+    {
+        var contextMock = Mocking.NewControllerContextMock<IControllerContext>();
+        var mock = Mocking.NewContextServiceMock(contextMock.Context.Object, null);
+        
+        Assert.Equal(contextMock.AuditEventBuilder.Object, mock.Object.Audit());
+        Assert.Equal(contextMock.Context.Object, mock.Object.GetContext());
+        contextMock.AuditEventBuilder.Verify(m => m.CausedBy(It.IsAny<IOnlinePlayer>()), Times.Never);
+    }
+
+    [Fact]
+    public void NewContextServiceMock_Sets_Up_Correctly_With_Actor()
+    {
+        var actor = new Mock<IOnlinePlayer>();
+        var contextMock = Mocking.NewControllerContextMock<IControllerContext>();
+        var mock = Mocking.NewContextServiceMock(contextMock.Context.Object, actor.Object);
+        
+        Assert.Equal(contextMock.AuditEventBuilder.Object, mock.Object.Audit());
+        Assert.Equal(contextMock.Context.Object, mock.Object.GetContext());
+        contextMock.AuditEventBuilder.Verify(m => m.CausedBy(actor.Object), Times.Once);
+    }
+    
+}

--- a/tests/EvoSC.Testing.Tests/MockingTests.cs
+++ b/tests/EvoSC.Testing.Tests/MockingTests.cs
@@ -1,6 +1,7 @@
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Models.Audit;
 using EvoSC.Manialinks.Interfaces;
 using EvoSC.Manialinks.Interfaces.Models;
 using EvoSC.Testing.Tests.TestClasses;
@@ -150,5 +151,44 @@ public class MockingTests
         Assert.Equal(contextMock.Context.Object, mock.Object.GetContext());
         contextMock.AuditEventBuilder.Verify(m => m.CausedBy(actor.Object), Times.Once);
     }
-    
+
+    [Fact]
+    public void NewLocaleMock_Returns_Simplified_Mock()
+    {
+        var context = Mocking.NewControllerContextMock<IPlayerInteractionContext>();
+        var locale = Mocking.NewLocaleMock(context.ContextService.Object);
+
+        var str = locale["SomeRandomLocale"];
+        
+        Assert.Equal("Test_Locale_String", str);
+    }
+
+    [Fact]
+    public void NewServerClientMock_Returns_Mocked_Client()
+    {
+        var server = Mocking.NewServerClientMock();
+        
+        Assert.NotNull(server.Remote);
+        Assert.Equal(server.Remote.Object, server.Client.Object.Remote);
+    }
+
+    [Fact]
+    public void NewAuditEventBuilderMock_Returns_Mock_With_No_Null_Methods()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        var mock = Mocking.NewAuditEventBuilderMock();
+        
+        Assert.NotNull(mock.Object.WithEventName(""));
+        Assert.NotNull(mock.Object.WithEventName(TestEnum.TestField));
+        Assert.NotNull(mock.Object.HavingProperties(new{}));
+        Assert.NotNull(mock.Object.WithStatus(AuditEventStatus.Info));
+        Assert.NotNull(mock.Object.Success());
+        Assert.NotNull(mock.Object.Info());
+        Assert.NotNull(mock.Object.Error());
+        Assert.NotNull(mock.Object.CausedBy(player.Object));
+        Assert.NotNull(mock.Object.Cancel());
+        Assert.NotNull(mock.Object.Cancel(true));
+        Assert.NotNull(mock.Object.UnCancel());
+        Assert.NotNull(mock.Object.Comment(""));
+    }
 }

--- a/tests/EvoSC.Testing.Tests/TestClasses/ITestService.cs
+++ b/tests/EvoSC.Testing.Tests/TestClasses/ITestService.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Testing.Tests.TestClasses;
+
+public interface ITestService
+{
+    public void DoSomethingElse();
+}

--- a/tests/EvoSC.Testing.Tests/TestClasses/TestController.cs
+++ b/tests/EvoSC.Testing.Tests/TestClasses/TestController.cs
@@ -1,0 +1,13 @@
+﻿using EvoSC.Common.Controllers;
+using EvoSC.Common.Interfaces.Controllers;
+
+namespace EvoSC.Testing.Tests.TestClasses;
+
+public class TestController : EvoScController<IPlayerInteractionContext>
+{
+    public Task DoingSomething()
+    {
+        Context.AuditEvent.Success();
+        return Task.CompletedTask;
+    }
+}

--- a/tests/EvoSC.Testing.Tests/TestClasses/TestControllerWithServices.cs
+++ b/tests/EvoSC.Testing.Tests/TestClasses/TestControllerWithServices.cs
@@ -1,0 +1,20 @@
+﻿using EvoSC.Common.Controllers;
+using EvoSC.Common.Interfaces.Controllers;
+
+namespace EvoSC.Testing.Tests.TestClasses;
+
+public class TestControllerWithServices : EvoScController<IPlayerInteractionContext>
+{
+    private ITestService _service;
+    
+    public TestControllerWithServices(ITestService service)
+    {
+        _service = service;
+    }
+    
+    public Task DoSomething()
+    {
+        _service.DoSomethingElse();
+        return Task.CompletedTask;
+    }
+}

--- a/tests/EvoSC.Testing.Tests/TestClasses/TestEnum.cs
+++ b/tests/EvoSC.Testing.Tests/TestClasses/TestEnum.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Testing.Tests.TestClasses;
+
+public enum TestEnum
+{
+    TestField
+}

--- a/tests/EvoSC.Testing.Tests/Usings.cs
+++ b/tests/EvoSC.Testing.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Modules/MapsModule.Tests/MapsControllerTests.cs
+++ b/tests/Modules/MapsModule.Tests/MapsControllerTests.cs
@@ -1,0 +1,103 @@
+using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Localization;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Models.Maps;
+using EvoSC.Modules.Official.Maps.Controllers;
+using EvoSC.Modules.Official.Maps.Events;
+using EvoSC.Modules.Official.Maps.Interfaces;
+using EvoSC.Testing;
+using EvoSC.Testing.Controllers;
+using GbxRemoteNet.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace EvoSC.Modules.Official.MapsModule.Tests;
+
+public class MapsControllerTests : CommandInteractionControllerTestBase<MapsController>
+{
+    private Mock<IOnlinePlayer> _actor = new();
+    private Mock<ILogger<MapsController>> _logger = new();
+    private Mock<IMxMapService> _mxMapService = new();
+    private Mock<IMapService> _mapService = new();
+    private Locale _locale;
+    private (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote) _server = Mocking.NewServerClientMock();
+    private Mock<IMap?> _map;
+
+    public MapsControllerTests()
+    {
+        _locale = Mocking.NewLocaleMock(ContextService.Object);
+        InitMock(_actor.Object, _logger, _mxMapService, _mapService, _server.Client, _locale);
+        
+        _map = new Mock<IMap?>();
+        _map.Setup(m => m.Name).Returns("MyMap");
+        _map.Setup(m => m.Author).Returns(_actor.Object);
+    }
+    
+    [Fact]
+    public async Task Map_Is_Added()
+    {
+        _mxMapService.Setup(m => m.FindAndDownloadMapAsync(123, null, _actor.Object))
+            .Returns(Task.FromResult(_map.Object));
+        
+        await Controller.AddMap("123");
+        
+        _mxMapService.Verify(m => m.FindAndDownloadMapAsync(123, null, _actor.Object), Times.Once);
+        AuditEventBuilder.Verify(m => m.Success(), Times.Once);
+        AuditEventBuilder.Verify(m => m.WithEventName(AuditEvents.MapAdded), Times.Once);
+        _server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Adding_Map_Failing_With_Exception_Is_Logged()
+    {
+        var ex = new Exception();
+        _mxMapService.Setup(m => m.FindAndDownloadMapAsync(123, null, _actor.Object))
+            .Returns(() => throw ex);
+
+        await Controller.AddMap("123");
+        
+        _logger.Verify(LogLevel.Information, ex, null, Times.Once());
+        _server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Adding_Map_Failing_With_Null_Return_Is_Logged()
+    {
+        _mxMapService.Setup(m => m.FindAndDownloadMapAsync(123, null, _actor.Object))
+            .Returns(Task.FromResult((IMap?)null));
+
+        await Controller.AddMap("123");
+        
+        _server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Map_Is_Removed()
+    {
+        _mapService.Setup(m => m.GetMapByIdAsync(123)).Returns(Task.FromResult(_map.Object));
+
+        await Controller.RemoveMap(123);
+        
+        _mapService.Verify(m => m.GetMapByIdAsync(123), Times.Once);
+        _mapService.Verify(m => m.RemoveMapAsync(123), Times.Once);
+        AuditEventBuilder.Verify(m => m.Success(), Times.Once);
+        AuditEventBuilder.Verify(m => m.WithEventName(AuditEvents.MapRemoved), Times.Once);
+        _server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+        _server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Never);
+        _logger.Verify(LogLevel.Information, null, null, Times.Once());
+    }
+
+    [Fact]
+    public async Task Map_Removal_Failed_Is_Reported()
+    {
+        _mapService.Setup(m => m.GetMapByIdAsync(123)).Returns(Task.FromResult((IMap?)null));
+
+        await Controller.RemoveMap(123);
+        
+        _mapService.Verify(m => m.RemoveMapAsync(123), Times.Never);
+        _server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), _actor.Object), Times.Never);
+        _server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+        AuditEventBuilder.Verify(m => m.Success(), Times.Never);
+    }
+}

--- a/tests/Modules/MapsModule.Tests/MapsModule.Tests.csproj
+++ b/tests/Modules/MapsModule.Tests/MapsModule.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>EvoSC.Modules.Official.MapsModule.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\EvoSC.Testing\EvoSC.Testing.csproj" />
+      <ProjectReference Include="..\..\..\src\Modules\MapsModule\MapsModule.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Modules/MapsModule.Tests/Usings.cs
+++ b/tests/Modules/MapsModule.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Modules/Player.Tests/Player.Tests.csproj
+++ b/tests/Modules/Player.Tests/Player.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>EvoSC.Modules.Official.Player.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\EvoSC.Testing\EvoSC.Testing.csproj" />
+      <ProjectReference Include="..\..\..\src\Modules\Player\Player.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Modules/Player.Tests/PlayerCommandsControllerTests.cs
+++ b/tests/Modules/Player.Tests/PlayerCommandsControllerTests.cs
@@ -1,0 +1,57 @@
+﻿using EvoSC.Common.Interfaces.Models;
+using EvoSC.Modules.Official.Player.Controllers;
+using EvoSC.Modules.Official.Player.Interfaces;
+using EvoSC.Testing.Controllers;
+using Moq;
+
+namespace EvoSC.Modules.Official.Player.Tests;
+
+public class PlayerCommandsControllerTests : CommandInteractionControllerTestBase<PlayerCommandsController>
+{
+    private Mock<IPlayerService> _playerService = new();
+    private Mock<IOnlinePlayer> _player = new();
+    
+    public PlayerCommandsControllerTests()
+    {
+        InitMock(_player.Object, _playerService);
+    }
+
+    [Fact]
+    public async Task Player_Is_Kicked()
+    {
+        await Controller.KickPlayerAsync(_player.Object);
+        _playerService.Verify(p => p.KickAsync(_player.Object, Context.Object.Player));
+    }
+    
+    [Fact]
+    public async Task Player_Is_Muted()
+    {
+        await Controller.MutePlayerAsync(_player.Object);
+        
+        _playerService.Verify(p => p.MuteAsync(_player.Object, Context.Object.Player));
+    }
+    
+    [Fact]
+    public async Task Player_Is_UnMuted()
+    {
+        await Controller.UnMutePlayerAsync(_player.Object);
+        
+        _playerService.Verify(p => p.UnmuteAsync(_player.Object, Context.Object.Player));
+    }
+    
+    [Fact]
+    public async Task Player_Is_Banned()
+    {
+        await Controller.BanPlayerAsync(_player.Object);
+        
+        _playerService.Verify(p => p.BanAsync(_player.Object, Context.Object.Player));
+    }
+    
+    [Fact]
+    public async Task Player_Is_Unbanned()
+    {
+        await Controller.UnbanPlayerAsync("ThePlayerLogin");
+        
+        _playerService.Verify(p => p.UnbanAsync("ThePlayerLogin", Context.Object.Player));
+    }
+}

--- a/tests/Modules/Player.Tests/PlayerEventControllerTests.cs
+++ b/tests/Modules/Player.Tests/PlayerEventControllerTests.cs
@@ -1,0 +1,27 @@
+﻿using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Modules.Official.Player.Controllers;
+using EvoSC.Modules.Official.Player.Interfaces;
+using EvoSC.Testing.Controllers;
+using GbxRemoteNet.Events;
+using Moq;
+
+namespace EvoSC.Modules.Official.Player.Tests;
+
+public class PlayerEventControllerTests : ControllerMock<PlayerEventController, IEventControllerContext>
+{
+    private Mock<IPlayerService> _playerService = new();
+
+    public PlayerEventControllerTests()
+    {
+        InitMock(_playerService);
+    }
+
+    [Fact]
+    public async Task Player_Is_Greeted_On_Join()
+    {
+        var args = new PlayerConnectGbxEventArgs {Login = "MyPlayerLogin"};
+        await Controller.OnPlayerConnect(null, args);
+
+        _playerService.Verify(s => s.UpdateAndGreetPlayerAsync(args.Login));
+    }
+}

--- a/tests/Modules/Player.Tests/PlayerServiceTests.cs
+++ b/tests/Modules/Player.Tests/PlayerServiceTests.cs
@@ -4,6 +4,8 @@ using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Localization;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util.Auditing;
+using EvoSC.Common.Util.Auditing;
 using EvoSC.Modules.Official.Player.Interfaces;
 using EvoSC.Modules.Official.Player.Services;
 using EvoSC.Testing;
@@ -46,7 +48,8 @@ public class PlayerServiceTests
         Mock<ILogger<PlayerService>> Logger,
         (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote) Server,
         Mock<IOnlinePlayer> Player,
-        Mock<IOnlinePlayer> Actor
+        Mock<IOnlinePlayer> Actor,
+        Mock<IAuditEventBuilder> Audit
         )
         NewPlayerServiceMock()
     {
@@ -71,7 +74,8 @@ public class PlayerServiceTests
             Logger: _logger,
             Server: server,
             Player: player,
-            Actor: _actor
+            Actor: _actor,
+            Audit: _commandContext.AuditEventBuilder
         );
     }
 
@@ -125,7 +129,7 @@ public class PlayerServiceTests
 
         await mock.PlayerService.KickAsync(mock.Player.Object, mock.Actor.Object);
         
-        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Server.Remote.Verify(m => m.KickAsync(PlayerLogin,""), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
     }
@@ -149,7 +153,7 @@ public class PlayerServiceTests
 
         await mock.PlayerService.MuteAsync(mock.Player.Object, mock.Actor.Object);
         
-        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Server.Remote.Verify(m => m.IgnoreAsync(PlayerLogin), Times.Once);
         mock.Server.Client.Verify(m => m.WarningMessageAsync(It.IsAny<string>(), mock.Player.Object), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
@@ -174,7 +178,7 @@ public class PlayerServiceTests
 
         await mock.PlayerService.UnmuteAsync(mock.Player.Object, mock.Actor.Object);
         
-        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Server.Remote.Verify(m => m.UnIgnoreAsync(PlayerLogin), Times.Once);
         mock.Server.Client.Verify(m => m.InfoMessageAsync(It.IsAny<string>(), mock.Player.Object), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
@@ -200,7 +204,7 @@ public class PlayerServiceTests
         
         mock.Server.Remote.Verify(m => m.BanAsync(PlayerLogin), Times.Once);
         mock.Server.Remote.Verify(m => m.BlackListAsync(PlayerLogin), Times.Once);
-        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
     }
     
@@ -216,7 +220,7 @@ public class PlayerServiceTests
         mock.Server.Remote.Verify(m => m.BanAsync(PlayerLogin), Times.Once);
         mock.Logger.Verify(LogLevel.Trace, ex, null, Times.Once());
         mock.Server.Remote.Verify(m => m.BlackListAsync(PlayerLogin), Times.Once);
-        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
     }
     
@@ -232,7 +236,7 @@ public class PlayerServiceTests
         mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
         mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
         mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), _actor.Object), Times.Exactly(2));
-        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(2));
+        mock.Audit.Verify(m => m.Success(), Times.Exactly(2));
     }
     
     [Fact]
@@ -248,7 +252,7 @@ public class PlayerServiceTests
         mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
         mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
         mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
-        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(1));
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Logger.Verify(LogLevel.Error, ex, null, Times.Once());
     }
     
@@ -265,7 +269,7 @@ public class PlayerServiceTests
         mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
         mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
         mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
-        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(1));
+        mock.Audit.Verify(m => m.Success(), Times.Once);
         mock.Logger.Verify(LogLevel.Error, ex, null, Times.Once());
     }
 }

--- a/tests/Modules/Player.Tests/PlayerServiceTests.cs
+++ b/tests/Modules/Player.Tests/PlayerServiceTests.cs
@@ -1,0 +1,93 @@
+﻿using EvoSC.Commands.Interfaces;
+using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Controllers;
+using EvoSC.Common.Interfaces.Localization;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Util;
+using EvoSC.Modules.Official.Player.Interfaces;
+using EvoSC.Modules.Official.Player.Services;
+using EvoSC.Testing;
+using EvoSC.Testing.Controllers;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace EvoSC.Modules.Official.Player.Tests;
+
+public class PlayerServiceTests
+{
+    private const string PlayerNickName = "snixtho";
+    private const string PlayerAccountId = "a467a996-eba5-44bf-9e2b-8543b50f39ae";
+    private const string PlayerLogin = "pGepluulRL-eK4VDtQ85rg";
+    
+    private Mock<IServerClient> _serverClient = new();
+    private Mock<ILogger<PlayerService>> _logger = new();
+    private Mock<IOnlinePlayer> _actor = new();
+    
+    private ControllerContextMock<IEventControllerContext> _eventContext;
+    private ControllerContextMock<ICommandInteractionContext> _commandContext;
+
+    public PlayerServiceTests()
+    {
+        _eventContext = Mocking.NewControllerContextMock<IEventControllerContext>();
+        _commandContext = Mocking.NewCommandInteractionContextMock(_actor.Object);
+
+        _actor.Setup(m => m.NickName).Returns(PlayerNickName);
+        _actor.Setup(m => m.AccountId).Returns(PlayerAccountId);
+    }
+
+    [Fact]
+    public async Task Player_Created_And_Greeted_On_First_Join()
+    {
+        var contextService = Mocking.NewContextServiceMock(_eventContext.Context.Object, null);
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+        
+        var playerManager = new Mock<IPlayerManagerService>();
+        playerManager.Setup(m => m.GetPlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer?)null));
+        playerManager.Setup(m => m.CreatePlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer)_actor.Object));
+
+        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
+        
+        await playerService.UpdateAndGreetPlayerAsync(PlayerLogin);
+        
+        playerManager.Verify(m => m.GetPlayerAsync(PlayerAccountId), Times.Once);
+        playerManager.Verify(m => m.CreatePlayerAsync(PlayerAccountId), Times.Once);
+        playerManager.Verify(m => m.UpdateLastVisitAsync(_actor.Object), Times.Once);
+        _serverClient.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
+    }
+
+    [Fact]
+    public async Task Player_Is_Greeted_When_Already_Exists()
+    {
+        var contextService = Mocking.NewContextServiceMock(_eventContext.Context.Object, null);
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+
+        var playerManager = new Mock<IPlayerManagerService>();
+        playerManager.Setup(m => m.GetPlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer)_actor.Object));
+        
+        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
+
+        await playerService.UpdateAndGreetPlayerAsync(PlayerLogin);
+        
+        playerManager.Verify(m => m.GetPlayerAsync(PlayerAccountId), Times.Once);
+        playerManager.Verify(m => m.UpdateLastVisitAsync(_actor.Object), Times.Once);
+        _serverClient.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
+    }
+
+    [Fact]
+    public async Task Player_Is_Kicked_And_Audited()
+    {
+        var contextService = Mocking.NewContextServiceMock(_commandContext.Context.Object, null);
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+        var playerManager = new Mock<IPlayerManagerService>();
+        var player = new Mock<IPlayer>();
+        player.Setup(m => m.AccountId).Returns(PlayerAccountId);
+
+        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
+
+        await playerService.KickAsync(player.Object, _actor.Object);
+        
+        // contextService.Verify(m => m.Audit().Success(), Times.Once); todo: make gbxremote testable
+        _serverClient.Verify(m => m.SuccessMessageAsync(It.IsAny<string>()), Times.Once);
+    }
+}

--- a/tests/Modules/Player.Tests/PlayerServiceTests.cs
+++ b/tests/Modules/Player.Tests/PlayerServiceTests.cs
@@ -4,11 +4,11 @@ using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Localization;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
-using EvoSC.Common.Util;
 using EvoSC.Modules.Official.Player.Interfaces;
 using EvoSC.Modules.Official.Player.Services;
 using EvoSC.Testing;
 using EvoSC.Testing.Controllers;
+using GbxRemoteNet.Interfaces;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -20,10 +20,8 @@ public class PlayerServiceTests
     private const string PlayerAccountId = "a467a996-eba5-44bf-9e2b-8543b50f39ae";
     private const string PlayerLogin = "pGepluulRL-eK4VDtQ85rg";
     
-    private Mock<IServerClient> _serverClient = new();
     private Mock<ILogger<PlayerService>> _logger = new();
     private Mock<IOnlinePlayer> _actor = new();
-    
     private ControllerContextMock<IEventControllerContext> _eventContext;
     private ControllerContextMock<ICommandInteractionContext> _commandContext;
 
@@ -34,6 +32,47 @@ public class PlayerServiceTests
 
         _actor.Setup(m => m.NickName).Returns(PlayerNickName);
         _actor.Setup(m => m.AccountId).Returns(PlayerAccountId);
+    }
+    
+    /// <summary>
+    /// Sets up mocks for the player service.
+    /// </summary>
+    /// <returns></returns>
+    private (
+        IPlayerService PlayerService,
+        Mock<IContextService> ContextService,
+        Locale Locale,
+        Mock<IPlayerManagerService> PlayerManager,
+        Mock<ILogger<PlayerService>> Logger,
+        (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote) Server,
+        Mock<IOnlinePlayer> Player,
+        Mock<IOnlinePlayer> Actor
+        )
+        NewPlayerServiceMock()
+    {
+        var contextService = Mocking.NewContextServiceMock(_commandContext.Context.Object, null);
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+        var playerManager = new Mock<IPlayerManagerService>();
+
+        var server = Mocking.NewServerClientMock();
+
+        var playerService = new PlayerService(playerManager.Object, server.Client.Object, _logger.Object,
+            contextService.Object, locale);
+
+        var player = new Mock<IOnlinePlayer>();
+        player.Setup(m => m.AccountId).Returns(PlayerAccountId);
+        player.Setup(m => m.NickName).Returns(PlayerNickName);
+
+        return (
+            PlayerService: playerService,
+            ContextService: contextService,
+            Locale: locale,
+            PlayerManager: playerManager,
+            Logger: _logger,
+            Server: server,
+            Player: player,
+            Actor: _actor
+        );
     }
 
     [Fact]
@@ -46,14 +85,16 @@ public class PlayerServiceTests
         playerManager.Setup(m => m.GetPlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer?)null));
         playerManager.Setup(m => m.CreatePlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer)_actor.Object));
 
-        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
+        var server = Mocking.NewServerClientMock();
+
+        var playerService = new PlayerService(playerManager.Object, server.Client.Object, _logger.Object, contextService.Object, locale);
         
         await playerService.UpdateAndGreetPlayerAsync(PlayerLogin);
         
         playerManager.Verify(m => m.GetPlayerAsync(PlayerAccountId), Times.Once);
         playerManager.Verify(m => m.CreatePlayerAsync(PlayerAccountId), Times.Once);
         playerManager.Verify(m => m.UpdateLastVisitAsync(_actor.Object), Times.Once);
-        _serverClient.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
+        server.Client.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
     }
 
     [Fact]
@@ -64,30 +105,167 @@ public class PlayerServiceTests
 
         var playerManager = new Mock<IPlayerManagerService>();
         playerManager.Setup(m => m.GetPlayerAsync(PlayerAccountId)).Returns(Task.FromResult((IPlayer)_actor.Object));
+
+        var server = Mocking.NewServerClientMock();
         
-        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
+        var playerService = new PlayerService(playerManager.Object, server.Client.Object, _logger.Object, contextService.Object, locale);
 
         await playerService.UpdateAndGreetPlayerAsync(PlayerLogin);
         
         playerManager.Verify(m => m.GetPlayerAsync(PlayerAccountId), Times.Once);
         playerManager.Verify(m => m.UpdateLastVisitAsync(_actor.Object), Times.Once);
-        _serverClient.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
+        server.Client.Verify(m => m.InfoMessageAsync(It.IsAny<string>()));
     }
 
     [Fact]
     public async Task Player_Is_Kicked_And_Audited()
     {
-        var contextService = Mocking.NewContextServiceMock(_commandContext.Context.Object, null);
-        var locale = Mocking.NewLocaleMock(contextService.Object);
-        var playerManager = new Mock<IPlayerManagerService>();
-        var player = new Mock<IPlayer>();
-        player.Setup(m => m.AccountId).Returns(PlayerAccountId);
+        var mock = NewPlayerServiceMock();
+        mock.Server.Remote.Setup(m => m.KickAsync(PlayerLogin, "")).Returns(Task.FromResult(true));
 
-        var playerService = new PlayerService(playerManager.Object, _serverClient.Object, _logger.Object, contextService.Object, locale);
-
-        await playerService.KickAsync(player.Object, _actor.Object);
+        await mock.PlayerService.KickAsync(mock.Player.Object, mock.Actor.Object);
         
-        // contextService.Verify(m => m.Audit().Success(), Times.Once); todo: make gbxremote testable
-        _serverClient.Verify(m => m.SuccessMessageAsync(It.IsAny<string>()), Times.Once);
+        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Server.Remote.Verify(m => m.KickAsync(PlayerLogin,""), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Player_Kicking_Failed_Sends_Error_Message()
+    {
+        var mock = NewPlayerServiceMock();
+
+        await mock.PlayerService.KickAsync(mock.Player.Object, mock.Actor.Object);
+
+        mock.ContextService.Verify(m => m.Audit(), Times.Never);
+        mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Player_Is_Muted_And_Audited()
+    {
+        var mock = NewPlayerServiceMock();
+        mock.Server.Remote.Setup(m => m.IgnoreAsync(PlayerLogin)).Returns(Task.FromResult(true));
+
+        await mock.PlayerService.MuteAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Server.Remote.Verify(m => m.IgnoreAsync(PlayerLogin), Times.Once);
+        mock.Server.Client.Verify(m => m.WarningMessageAsync(It.IsAny<string>(), mock.Player.Object), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Player_Is_Muting_Failed_Sends_Error_Message()
+    {
+        var mock = NewPlayerServiceMock();
+
+        await mock.PlayerService.MuteAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.ContextService.Verify(m => m.Audit(), Times.Never);
+        mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Player_Is_UnMuted_And_Audited()
+    {
+        var mock = NewPlayerServiceMock();
+        mock.Server.Remote.Setup(m => m.UnIgnoreAsync(PlayerLogin)).Returns(Task.FromResult(true));
+
+        await mock.PlayerService.UnmuteAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Server.Remote.Verify(m => m.UnIgnoreAsync(PlayerLogin), Times.Once);
+        mock.Server.Client.Verify(m => m.InfoMessageAsync(It.IsAny<string>(), mock.Player.Object), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Player_Is_UnMuting_Failed_Sends_Error_Message()
+    {
+        var mock = NewPlayerServiceMock();
+
+        await mock.PlayerService.MuteAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.ContextService.Verify(m => m.Audit(), Times.Never);
+        mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+
+    [Fact]
+    public async Task Player_Is_Banned_Blacklisted_And_Audited()
+    {
+        var mock = NewPlayerServiceMock();
+
+        await mock.PlayerService.BanAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.Server.Remote.Verify(m => m.BanAsync(PlayerLogin), Times.Once);
+        mock.Server.Remote.Verify(m => m.BlackListAsync(PlayerLogin), Times.Once);
+        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Player_Banning_Failed_Still_Blacklists_And_Logs_Trace()
+    {
+        var mock = NewPlayerServiceMock();
+        var ex = new Exception();
+        mock.Server.Remote.Setup(m => m.BanAsync(PlayerLogin)).Returns(() => throw ex);
+
+        await mock.PlayerService.BanAsync(mock.Player.Object, mock.Actor.Object);
+        
+        mock.Server.Remote.Verify(m => m.BanAsync(PlayerLogin), Times.Once);
+        mock.Logger.Verify(LogLevel.Trace, ex, null, Times.Once());
+        mock.Server.Remote.Verify(m => m.BlackListAsync(PlayerLogin), Times.Once);
+        mock.ContextService.Verify(m => m.Audit(), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), mock.Actor.Object), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Player_Is_Unbanned_And_Audited()
+    {
+        var mock = NewPlayerServiceMock();
+        mock.Server.Remote.Setup(m => m.UnBanAsync(PlayerLogin)).Returns(Task.FromResult(true));
+        mock.Server.Remote.Setup(m => m.UnBlackListAsync(PlayerLogin)).Returns(Task.FromResult(true));
+
+        await mock.PlayerService.UnbanAsync(PlayerLogin, mock.Actor.Object);
+        
+        mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
+        mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
+        mock.Server.Client.Verify(m => m.SuccessMessageAsync(It.IsAny<string>(), _actor.Object), Times.Exactly(2));
+        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(2));
+    }
+    
+    [Fact]
+    public async Task Player_Unban_Failed_Is_Logged_And_Still_Unblacklisted()
+    {
+        var mock = NewPlayerServiceMock();
+        var ex = new Exception();
+        mock.Server.Remote.Setup(m => m.UnBanAsync(PlayerLogin)).Returns(() => throw ex);
+        mock.Server.Remote.Setup(m => m.UnBlackListAsync(PlayerLogin)).Returns(Task.FromResult(true));
+
+        await mock.PlayerService.UnbanAsync(PlayerLogin, mock.Actor.Object);
+        
+        mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
+        mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
+        mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(1));
+        mock.Logger.Verify(LogLevel.Error, ex, null, Times.Once());
+    }
+    
+    [Fact]
+    public async Task Player_Unblacklist_Failed_Sends_ErrorMsg_And_ErrorLog()
+    {
+        var mock = NewPlayerServiceMock();
+        var ex = new Exception();
+        mock.Server.Remote.Setup(m => m.UnBanAsync(PlayerLogin)).Returns(Task.FromResult(true));
+        mock.Server.Remote.Setup(m => m.UnBlackListAsync(PlayerLogin)).Returns(() => throw ex);
+
+        await mock.PlayerService.UnbanAsync(PlayerLogin, mock.Actor.Object);
+        
+        mock.Server.Remote.Verify(m => m.UnBanAsync(PlayerLogin), Times.Once);
+        mock.Server.Remote.Verify(m => m.UnBlackListAsync(PlayerLogin), Times.Once);
+        mock.Server.Client.Verify(m => m.ErrorMessageAsync(It.IsAny<string>(), _actor.Object), Times.Once);
+        mock.ContextService.Verify(m => m.Audit(), Times.Exactly(1));
+        mock.Logger.Verify(LogLevel.Error, ex, null, Times.Once());
     }
 }

--- a/tests/Modules/Player.Tests/Usings.cs
+++ b/tests/Modules/Player.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Modules/SetName.Tests/SetName.Tests.csproj
+++ b/tests/Modules/SetName.Tests/SetName.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>EvoSC.Modules.Official.SetName.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\EvoSC.Testing\EvoSC.Testing.csproj" />
+      <ProjectReference Include="..\..\..\src\Modules\SetName\SetName.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Modules/SetName.Tests/SetNameCommandsControllerTests.cs
+++ b/tests/Modules/SetName.Tests/SetNameCommandsControllerTests.cs
@@ -1,0 +1,32 @@
+using EvoSC.Common.Interfaces.Localization;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Interfaces;
+using EvoSC.Modules.Official.SetName.Controllers;
+using EvoSC.Testing;
+using EvoSC.Testing.Controllers;
+using Moq;
+
+namespace EvoSC.Modules.Official.SetName.Tests;
+
+public class SetNameCommandsControllerTests : CommandInteractionControllerTestBase<SetNameCommandsController>
+{
+    private Mock<IOnlinePlayer> _actor = new();
+    private Mock<IManialinkManager> _manialinkManager = new();
+    private Locale _locale;
+
+    public SetNameCommandsControllerTests()
+    {
+        _locale = Mocking.NewLocaleMock(ContextService.Object);
+        
+        InitMock(_actor.Object, _manialinkManager, _locale);
+    }
+    
+    [Fact]
+    public async Task SetName_Dialog_Is_Opened()
+    {
+        await Controller.SetNameAsync();
+
+        _manialinkManager.Verify(m =>
+            m.SendManialinkAsync(_actor.Object, "SetName.EditName", It.IsAny<It.IsAnyType>()));
+    }
+}

--- a/tests/Modules/SetName.Tests/SetNameControllerTests.cs
+++ b/tests/Modules/SetName.Tests/SetNameControllerTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Dynamic;
+using EvoSC.Common.Interfaces.Localization;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Manialinks.Interfaces.Models;
+using EvoSC.Modules.Official.SetName.Controllers;
+using EvoSC.Modules.Official.SetName.Interfaces;
+using EvoSC.Modules.Official.SetName.Models;
+using EvoSC.Testing;
+using EvoSC.Testing.Controllers;
+using Moq;
+
+namespace EvoSC.Modules.Official.SetName.Tests;
+
+public class SetNameControllerTests : ManialinkControllerTestBase<SetNameController>
+{
+    private Mock<IManialinkActionContext> _manialinkActionContext = new();
+    private Mock<IOnlinePlayer> _actor = new();
+    private Mock<ISetNameService> _setNameService = new();
+    private Locale _locale;
+
+    public SetNameControllerTests()
+    {
+        _locale = Mocking.NewLocaleMock(ContextService.Object);
+        
+        InitMock(_actor.Object, _manialinkActionContext.Object, _setNameService, _locale);
+    }
+
+    [Fact]
+    public async Task Edit_Name_Action_Is_Success()
+    {
+        var entry = new SetNameEntryModel {Nickname = "MyNickname"};
+        _manialinkActionContext.Setup(m => m.EntryModel).Returns(entry);
+
+        await Controller.ValidateModelAsync();
+        await Controller.EditNameAsync(entry);
+
+        _setNameService.Verify(m => m.SetNicknameAsync(_actor.Object, entry.Nickname), Times.Once);
+        ManialinkManager.Verify(m => m.HideManialinkAsync(_actor.Object, "SetName.EditName"), Times.Once);
+        AuditEventBuilder.Verify(m => m.Success(), Times.Once);
+        AuditEventBuilder.Verify(m => m.WithEventName("EditNickname"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Invalid_Entry_Model_Shows_Manialink_Again()
+    {
+        var entry = new SetNameEntryModel {Nickname = ""};
+        _manialinkActionContext.Setup(m => m.EntryModel).Returns(entry);
+        await Controller.ValidateModelAsync();
+        await Controller.EditNameAsync(entry);
+        
+        _setNameService.Verify(m => m.SetNicknameAsync(_actor.Object, entry.Nickname), Times.Never);
+        ManialinkManager.Verify(m => m.SendManialinkAsync(_actor.Object, "SetName.EditName", It.IsAny<ExpandoObject>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SetName_Is_Canceled()
+    {
+        await Controller.CancelAsync();
+        
+        ManialinkManager.Verify(m => m.HideManialinkAsync(_actor.Object, "SetName.EditName"));
+    }
+}

--- a/tests/Modules/SetName.Tests/SetNameServiceTests.cs
+++ b/tests/Modules/SetName.Tests/SetNameServiceTests.cs
@@ -1,0 +1,60 @@
+﻿using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Database.Repository;
+using EvoSC.Common.Interfaces.Models;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Manialinks.Interfaces;
+using EvoSC.Manialinks.Interfaces.Models;
+using EvoSC.Modules.Official.SetName.Events;
+using EvoSC.Modules.Official.SetName.Services;
+using EvoSC.Testing;
+using Moq;
+
+namespace EvoSC.Modules.Official.SetName.Tests;
+
+public class SetNameServiceTests
+{
+    [Fact]
+    public async Task Name_Is_Set_And_Updated_In_Caches()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        player.Setup(m => m.NickName).Returns("OldName");
+        var mlAction = new Mock<IManialinkActionContext>();
+        var mlManager = new Mock<IManialinkManager>();
+        var context = Mocking.NewManialinkInteractionContextMock(player.Object, mlAction.Object, mlManager.Object);
+        var contextService = Mocking.NewContextServiceMock(context.Context.Object, null);
+        var server = Mocking.NewServerClientMock();
+        var playerRepository = new Mock<IPlayerRepository>();
+        var playerCache = new Mock<IPlayerCacheService>();
+        var eventManager = new Mock<IEventManager>();
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+
+        var service = new SetNameService(server.Client.Object, playerRepository.Object, playerCache.Object,
+            eventManager.Object, locale);
+
+        await service.SetNicknameAsync(player.Object, "NewName");
+
+        playerRepository.Verify(m => m.UpdateNicknameAsync(player.Object, "NewName"), Times.Once);
+        playerCache.Verify(m => m.UpdatePlayerAsync(player.Object));
+        eventManager.Verify(m => m.RaiseAsync(SetNameEvents.NicknameUpdated, It.IsAny<NicknameUpdatedEventArgs>()));
+    }
+
+    [Fact]
+    public async Task Name_Equals_Old_Name_Wont_Update()
+    {
+        var player = new Mock<IOnlinePlayer>();
+        player.Setup(m => m.NickName).Returns("OldName");
+        var mlAction = new Mock<IManialinkActionContext>();
+        var mlManager = new Mock<IManialinkManager>();
+        var context = Mocking.NewManialinkInteractionContextMock(player.Object, mlAction.Object, mlManager.Object);
+        var contextService = Mocking.NewContextServiceMock(context.Context.Object, null);
+        var playerRepository = new Mock<IPlayerRepository>();
+        var locale = Mocking.NewLocaleMock(contextService.Object);
+        var server = Mocking.NewServerClientMock();
+        
+        var service = new SetNameService(server.Client.Object, playerRepository.Object, null, null, locale);
+
+        await service.SetNicknameAsync(player.Object, "OldName");
+        
+        playerRepository.Verify(m => m.UpdateNicknameAsync(player.Object, "NewName"), Times.Never);
+    }
+}

--- a/tests/Modules/SetName.Tests/Usings.cs
+++ b/tests/Modules/SetName.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
- Updated GbxRemote.NET with it's new mockable client.
- Added several helper methods to create mocks for mocking controllers and services within a context.
- Tests can inherit controller context classes to simplify controller testing.
- Added the new testing methods to some modules.
- Small API change: controllers should now specify the context type's interface instead of class. This makes them testable.