### PR TITLE
Update link to create server credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ services:
       - 2350:2350/tcp
       - "5001:5000/tcp" # Be careful opening XMLRPC! Only if you really need to.
     environment:
-      MASTER_LOGIN: "CHANGEME :)" # Create server credentials at https://players.trackmania.com
-      MASTER_PASSWORD: "CHANGEME :)" # Create server credentials at https://players.trackmania.com
+      MASTER_LOGIN: "CHANGEME :)" # Create server credentials at https://www.trackmania.com/player/dedicated-servers
+      MASTER_PASSWORD: "CHANGEME :)" # Create server credentials at https://www.trackmania.com/player/dedicated-servers
       XMLRPC_ALLOWREMOTE: "True"
     volumes:
       - UserData:/server/UserData


### PR DESCRIPTION
Update the link to use to create server credentials for the Docker Compose flow. The existing one seems to redirect to the Trackmania homepage instead of the correct page now.

I left out updating versions as it's just a readme change, but let me know if I need to and I'll do it!