### PR TITLE
Update docker compose and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It sets up a TM2020 dedicated server for you as well as all the required other s
 version: "3.8"
 services:
   trackmania:
-    image: evotm/trackmania
+    image: evoesports/trackmania
     ports:
       - 2350:2350/udp
       - 2350:2350/tcp

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   trackmania:
-    image: evotm/trackmania
+    image: evoesports/trackmania
     restart: always
     ports:
       - 2350:2350/udp


### PR DESCRIPTION
Update to new trackmania image, and likewise evosc_sharp.

Prior to this change, docker compose would fail, as the old trackmania image (deprecated) no longer exists. Same for the previous evosc_sharp.

Old trackmania image (with deprecation note):
https://hub.docker.com/r/evotm/trackmania

Old evosc_sharp:
https://hub.docker.com/r/evoesports/evoscsharp (does not exist)


![WindowsTerminal_X0ambuy4ou](https://github.com/user-attachments/assets/c7908935-a3a4-4dd1-90f0-8545a6722285)

I have not updated the EvoSC.csproj version number, as I assumed it wont be required for this change.