### PR TITLE
Fix missing Moq dep in TeamChat tests

### DIFF
--- a/tests/Modules/TeamChatModule.Tests/TeamChatModule.Tests.csproj
+++ b/tests/Modules/TeamChatModule.Tests/TeamChatModule.Tests.csproj
@@ -10,8 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Adding Moq to the TeamChatModule resolves the issue I had on windows where I could not manage to get dotnet to resolve the and install the dependency.

Previously, if I ran `dotnet list package` inside of `tests\Modules\TeamChatModule.Tests` , Moq would be missing. With this change, it is now present:

```
Project 'TeamChatModule.Tests' has the following package references
   [net8.0]:
   Top-level Package                Requested   Resolved
   > coverlet.collector             6.0.0       6.0.0
   > Microsoft.NET.Test.Sdk         17.6.0      17.6.0
   > Moq                            4.20.70     4.20.70
   > xunit                          2.4.2       2.4.2
   > xunit.runner.visualstudio      2.4.5       2.4.5
```

The Moq specific build error I got on windows is also **gone**.
```
Build FAILED.

C:\repos\EvoSC-sharp\tests\Modules\TeamChatModule.Tests\Middlewares\TeamChatMiddlewareTests.cs(9,7): error CS0246: The type or namespace name 'Moq' could not be found (are you missing a using directive or an
assembly reference?) [C:\repos\EvoSC-sharp\tests\Modules\TeamChatModule.Tests\TeamChatModule.Tests.csproj]
```

I have not increased the versions in `EvoSC.csproj` or the `README.md`, as it did not make sense to me to do, nor did I find any version numbers to bump that made sense to bump.