### PR TITLE
Replace ** and Recursivedir for FastestCP test

### DIFF
--- a/tests/Modules/FastestCp.Tests/FastestCp.Tests.csproj
+++ b/tests/Modules/FastestCp.Tests/FastestCp.Tests.csproj
@@ -35,9 +35,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ContentWithTargetPath Include="**\*.xml">
+        <ContentWithTargetPath Include="Manialinks\*.xml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <TargetPath>%(RecursiveDir)\%(Filename)%(Extension)</TargetPath>
+            <TargetPath>Manialinks\%(Filename)%(Extension)</TargetPath>
         </ContentWithTargetPath>
     </ItemGroup>
 


### PR DESCRIPTION
When building on windows via commandline (both cmd and pwsh), it would fail to find the Manialinks in FastestCP tests, and could also accidentally create a bunch of recursive folders while trying to copy said files.

Testing building via powershell on windows, by being in the git root, and running `dotnet build`

It now successfully finds the manialinks, and no longer recursively creates nested `bin\Debug\net8.0` folders.

If someone on links could confirm that building still works, that would be most appreciated