### PR TITLE
WRM: Handle Flurl http exceptions

### DIFF
--- a/src/Modules/WorldRecordModule/Interfaces/IWorldRecordService.cs
+++ b/src/Modules/WorldRecordModule/Interfaces/IWorldRecordService.cs
@@ -6,18 +6,19 @@ namespace EvoSC.Modules.Official.WorldRecordModule.Interfaces;
 public interface IWorldRecordService
 {
     /// <summary>
-    /// Trigger a fetch for records from trackmania.io
+    /// Trigger a fetch for records from trackmania.io.
+    /// If an error occurs during the API fetch, the method will log the error and use AT instead.
     /// </summary>
     /// <param name="mapUid">The UID of the map to load records from.</param>
     /// <returns></returns>
     public Task FetchRecordAsync(string mapUid);
-    
+
     /// <summary>
     /// Clears the currently loaded world record.
     /// </summary>
     /// <returns></returns>
     public Task ClearRecordAsync();
-    
+
     /// <summary>
     /// Gets the currently loaded world record or null.
     /// </summary>


### PR DESCRIPTION
Instead of throwing, we log an error message, and let it continue. This will let it use the local author record, and not crash.

Update comment to inform about the possibility of it returning without completing in the event of API errors.

Fixed whitespace and formatting

Fixes #294

Tested locally on my machine with a custom made map that was not uploaded. It didnt crash/throw, and the AT was loaded. Tested a known good online map, and it correctly loaded the WR.

Bad map, log output:
```
30.09.2024 08:56:47.5159] fail: EvoSC.Modules.Official.WorldRecordModule.Services.WorldRecordService[0] Error fetching data from trackmania.io API. Status code: 500 Flurl.Http.FlurlHttpException: 

Call failed with status code 500 (Internal Server Error):GET https://trackmania.io/api/leaderboard/map/fbZzfRsYokp1Zpp0GoXokjYLuuj    

at Flurl.Http..... long stack trace ...

[30.09.2024 08:57:08.3710] dbug: EvoSC.Modules.Official.WorldRecordModule.Services.WorldRecordService[0] Couldn't load World Record, using Author Time instead.
```