### PR TITLE
Enable/disable local records chat messages via config

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Download PR number artifact
         if: github.event.workflow_run.event == 'pull_request'
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v9
         with:
           workflow: Java CI
           run_id: ${{ github.event.workflow_run.id }}
@@ -36,12 +36,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'oracle'
           java-version: '17'
           
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -57,7 +57,7 @@ jobs:
           git clean -ffdx && git reset --hard HEAD
       
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -65,7 +65,7 @@ jobs:
           
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/src/Modules/LocalRecordsModule/Config/ILocalRecordsSettings.cs
+++ b/src/Modules/LocalRecordsModule/Config/ILocalRecordsSettings.cs
@@ -15,5 +15,7 @@ public interface ILocalRecordsSettings
     
     [Option(DefaultValue = 100), Description("Maximum number of local records to keep track of per map.")]
     public int MaxRecordsPerMap { get; }
+    
+    [Option(DefaultValue = true), Description("Send chat messages when a new local record has been achieved.")]
+    public bool SendChatMessages { get; }
 }
-

--- a/tests/Modules/LocalRecordsModule.Tests/Services/LocalRecordsServiceTests.cs
+++ b/tests/Modules/LocalRecordsModule.Tests/Services/LocalRecordsServiceTests.cs
@@ -257,7 +257,9 @@ public class LocalRecordsServiceTests
         mock.LocalRecordRepository
             .Setup(m => m.AddOrUpdateRecordAsync(newPb.Map, newPb))
             .ReturnsAsync(localRecord);
-
+        
+        mock.Settings.Setup(m => m.SendChatMessages).Returns(true);
+        
         await mock.Service.UpdatePbAsync(newPb);
 
         mock.Server.Chat.Verify(m => m.InfoMessageAsync(It.Is<string>(s => s.Contains("gained the"))), Times.Once);
@@ -286,7 +288,9 @@ public class LocalRecordsServiceTests
         mock.LocalRecordRepository
             .Setup(m => m.AddOrUpdateRecordAsync(newPb.Map, newPb))
             .ReturnsAsync(localRecord);
-
+        
+        mock.Settings.Setup(m => m.SendChatMessages).Returns(true);
+        
         await mock.Service.UpdatePbAsync(newPb);
 
         mock.Server.Chat.Verify(m => m.InfoMessageAsync(It.Is<string>(s => s.Contains("claimed"))), Times.Once);
@@ -316,6 +320,8 @@ public class LocalRecordsServiceTests
             .Setup(m => m.AddOrUpdateRecordAsync(newPb.Map, newPb))
             .ReturnsAsync(localRecord);
 
+        mock.Settings.Setup(m => m.SendChatMessages).Returns(true);
+        
         await mock.Service.UpdatePbAsync(newPb);
 
         mock.Server.Chat.Verify(m => m.InfoMessageAsync(It.Is<string>(s => s.Contains("improved their"))), Times.Once);
@@ -339,6 +345,8 @@ public class LocalRecordsServiceTests
         mock.LocalRecordRepository
             .Setup(m => m.AddOrUpdateRecordAsync(newPb.Map, newPb))
             .ReturnsAsync(localRecord);
+        
+        mock.Settings.Setup(m => m.SendChatMessages).Returns(true);
 
         await mock.Service.UpdatePbAsync(newPb);
 


### PR DESCRIPTION
Adds a new setting in the local records module, where the serveradmin can configure whether or not the chat should be notified about new local records. This feature was added to remove the spam the chat gets when you have several people on the same server on a brand new map for competitions, e.g. Dirt weekly.

Closes #324 