### PR TITLE
Support longtext for MySQL in MatchRecords table

### DIFF
--- a/src/Modules/MatchTrackerModule/Migrations/20250311141800_ChangeDatatypeOfReport.cs
+++ b/src/Modules/MatchTrackerModule/Migrations/20250311141800_ChangeDatatypeOfReport.cs
@@ -1,0 +1,21 @@
+﻿using EvoSC.Modules.Official.MatchTrackerModule.Models.Database;
+using FluentMigrator;
+
+namespace EvoSC.Modules.Official.MatchTrackerModule.Migrations;
+
+[Migration(1741699715)]
+public class ChangeDatatypeOfReport : Migration {
+    
+    public const string TableName = "MatchRecords";
+    public const string ReportColumn = "Report";
+    
+    public override void Up()
+    {
+        IfDatabase("mysql").Alter.Table(TableName).AlterColumn(ReportColumn).AsCustom("LONGTEXT");
+    }
+    
+    public override void Down()
+    {
+        IfDatabase("mysql").Alter.Table(TableName).AlterColumn(ReportColumn).AsCustom("TEXT");
+    } 
+}


### PR DESCRIPTION
Changes the datatype of the reports column in MySQL from TEXT to LONGTEXT to support over 65,000 characters.