### PR TITLE
Fix map adding

### DIFF
--- a/src/EvoSC.CLI/CliStartup.cs
+++ b/src/EvoSC.CLI/CliStartup.cs
@@ -68,10 +68,13 @@ public static class CliStartup
             .Services(AppFeature.PlayerCache, s => s
                     .RegisterSingleton<IPlayerCacheService, PlayerCacheService>()
                 , "Logging", "Events", "Database", "GbxRemoteClient", "ActionInitializePlayerCache")
-
-            .Services(AppFeature.MatchSettings, s => s
-                    .Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient)
-                , "Logging", "GbxRemoteClient", "Config")
+            
+            .Services(AppFeature.MatchSettings, s =>
+            {
+                s.Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient);
+                s.RegisterSingleton<IMatchSettingsTrackerService, MatchSettingsTrackerService>();
+                s.RegisterSingleton<IMatchSettingsMaplistUpdateService, MatchSettingsMaplistUpdateService>();
+            }, "Logging", "GbxRemoteClient", "Config", "Events")
 
             .Services(AppFeature.Auditing, s => s
                     .Register<IAuditService, AuditService>(Lifestyle.Transient)

--- a/src/EvoSC.CLI/CliStartup.cs
+++ b/src/EvoSC.CLI/CliStartup.cs
@@ -111,9 +111,7 @@ public static class CliStartup
                 .GetInstance<IEventManager>()
             )
 
-            .Action("ActionInitializePlayerCache", s => s
-                .GetInstance<IPlayerCacheService>()
-            )
+            .AsyncAction("InitializeCaches", InitializeCachesAsync)
 
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                     .GetInstance<IManialinkInteractionHandler>()
@@ -148,6 +146,19 @@ public static class CliStartup
         // main migrations
         manager.MigrateFromAssembly(typeof(MigrationManager).Assembly);
     }
+    
+    /// <summary>
+    /// Creates the singleton instances of caches and runs
+    /// initialization methods to make them ready.
+    /// </summary>
+    /// <param name="s"></param>
+    private static async Task InitializeCachesAsync(ServicesBuilder s)
+    {
+        var msTrackerService = s.GetInstance<IMatchSettingsTrackerService>();
+        await msTrackerService.SetDefaultMatchSettingsAsync();
+        
+        s.GetInstance<IPlayerCacheService>();
+    }
 
     /// <summary>
     /// Connect to XMLRPC and initialize server callback and chat router.
@@ -160,5 +171,4 @@ public static class CliStartup
         s.GetInstance<IRemoteChatRouter>();
         await serverClient.StartAsync(CancellationToken.None);
     }
-    
 }

--- a/src/EvoSC.Common/Config/Models/IPathConfig.cs
+++ b/src/EvoSC.Common/Config/Models/IPathConfig.cs
@@ -10,6 +10,6 @@ public interface IPathConfig
     public string Maps { get; }
     
     [Description("Default match settings file")]
-    [Option(Alias = "defaultMatchSettings", DefaultValue = "example.txt")]
+    [Option(Alias = "defaultMatchSettings", DefaultValue = "example")]
     public string DefaultMatchSettings { get; }
 }

--- a/src/EvoSC.Common/Database/Repository/Maps/MapRepository.cs
+++ b/src/EvoSC.Common/Database/Repository/Maps/MapRepository.cs
@@ -99,6 +99,7 @@ public class MapRepository(IDbConnectionFactory dbConnFactory, ILogger<MapReposi
         try
         {
             await Database.InsertAsync(dbMapDetails);
+            await transaction.CommitTransactionAsync();
         }
         catch (Exception ex)
         {
@@ -110,43 +111,24 @@ public class MapRepository(IDbConnectionFactory dbConnFactory, ILogger<MapReposi
         return dbMapDetails;
     }
 
-    public async Task<IMap> UpdateMapAsync(long mapId, MapMetadata map)
+    public async Task<IMap> UpdateMapAsync(DbMap map)
     {
-        var updatedMap = new DbMap
-        {
-            Id = mapId,
-            Uid = map.MapUid,
-            Enabled = true,
-            Name = map.MapName,
-            ExternalId = map.ExternalId,
-            ExternalVersion = map.ExternalVersion,
-            ExternalMapProvider = map.ExternalMapProvider,
-            UpdatedAt = DateTime.Now
-        };
-
         await using var transaction = await Database.BeginTransactionAsync();
+        
         try
         {
-            await Table<DbMap>()
-                .Where(m => m.Id == updatedMap.Id)
-                .Set(m => m.Uid, updatedMap.Uid)
-                .Set(m => m.Enabled, updatedMap.Enabled)
-                .Set(m => m.Name, updatedMap.Name)
-                .Set(m => m.ExternalId, updatedMap.ExternalId)
-                .Set(m => m.ExternalVersion, updatedMap.ExternalVersion)
-                .Set(m => m.ExternalMapProvider, updatedMap.ExternalMapProvider)
-                .Set(m => m.UpdatedAt, updatedMap.UpdatedAt)
-                .UpdateAsync();
+            await Database.UpdateAsync(map);
             await transaction.CommitTransactionAsync();
+            
+            return new Map(map);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            logger.LogError(e, "Failed to update map with UID {MapMapUid}", map.MapUid);
             await transaction.RollbackTransactionAsync();
-            throw new EvoScDatabaseException($"Failed to update map with UID {map.MapUid}", e);
+            
+            logger.LogError(ex, "Failed to update map with UID {MapMapUid}", map.Uid);
+            throw new EvoScDatabaseException($"Failed to update map with UID {map.Uid}", ex);
         }
-
-        return new Map(updatedMap);
     }
 
     public Task RemoveMapAsync(long id) => 

--- a/src/EvoSC.Common/Database/Repository/Maps/MapRepository.cs
+++ b/src/EvoSC.Common/Database/Repository/Maps/MapRepository.cs
@@ -126,7 +126,7 @@ public class MapRepository(IDbConnectionFactory dbConnFactory, ILogger<MapReposi
         {
             await transaction.RollbackTransactionAsync();
             
-            logger.LogError(ex, "Failed to update map with UID {MapMapUid}", map.Uid);
+            logger.LogError(ex, "Failed to update map with UID {MapUid}", map.Uid);
             throw new EvoScDatabaseException($"Failed to update map with UID {map.Uid}", ex);
         }
     }

--- a/src/EvoSC.Common/Events/Arguments/MapEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MapEventArgs.cs
@@ -4,5 +4,8 @@ namespace EvoSC.Common.Events.Arguments;
 
 public class MapEventArgs : EventArgs
 {
+    /// <summary>
+    /// The map that was changed.
+    /// </summary>
     public IMap Map { get; init; }
 }

--- a/src/EvoSC.Common/Events/Arguments/MapEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MapEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Models;
+
+namespace EvoSC.Common.Events.Arguments;
+
+public class MapEventArgs : EventArgs
+{
+    public IMap Map { get; init; }
+}

--- a/src/EvoSC.Common/Events/Arguments/MapUpdatedEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MapUpdatedEventArgs.cs
@@ -4,5 +4,8 @@ namespace EvoSC.Common.Events.Arguments;
 
 public class MapUpdatedEventArgs : MapEventArgs
 {
+    /// <summary>
+    /// Information about the previous map that was updated.
+    /// </summary>
     public IMap OldMap { get; set; }
 }

--- a/src/EvoSC.Common/Events/Arguments/MapUpdatedEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MapUpdatedEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Models;
+
+namespace EvoSC.Common.Events.Arguments;
+
+public class MapUpdatedEventArgs : MapEventArgs
+{
+    public IMap OldMap { get; set; }
+}

--- a/src/EvoSC.Common/Events/Arguments/MatchSettings/MatchSettingsEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MatchSettings/MatchSettingsEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Util;
+
+namespace EvoSC.Common.Events.Arguments.MatchSettings;
+
+public class MatchSettingsEventArgs : EventArgs
+{
+    public IMatchSettings MatchSettings { get; init; }
+}

--- a/src/EvoSC.Common/Events/Arguments/MatchSettings/MatchSettingsEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MatchSettings/MatchSettingsEventArgs.cs
@@ -4,5 +4,8 @@ namespace EvoSC.Common.Events.Arguments.MatchSettings;
 
 public class MatchSettingsEventArgs : EventArgs
 {
+    /// <summary>
+    /// The changed matchsettings.
+    /// </summary>
     public IMatchSettings MatchSettings { get; init; }
 }

--- a/src/EvoSC.Common/Events/Arguments/MatchSettings/ScriptSettingsChangedEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MatchSettings/ScriptSettingsChangedEventArgs.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Common.Events.Arguments.MatchSettings;
+
+public class ScriptSettingsChangedEventArgs : EventArgs
+{
+    public Dictionary<string, object> NewScriptSettings { get; init; }
+}

--- a/src/EvoSC.Common/Events/Arguments/MatchSettings/ScriptSettingsChangedEventArgs.cs
+++ b/src/EvoSC.Common/Events/Arguments/MatchSettings/ScriptSettingsChangedEventArgs.cs
@@ -2,5 +2,8 @@
 
 public class ScriptSettingsChangedEventArgs : EventArgs
 {
+    /// <summary>
+    /// The new script settings that were set.
+    /// </summary>
     public Dictionary<string, object> NewScriptSettings { get; init; }
 }

--- a/src/EvoSC.Common/Events/CoreEvents/MapEvent.cs
+++ b/src/EvoSC.Common/Events/CoreEvents/MapEvent.cs
@@ -1,8 +1,22 @@
 ﻿namespace EvoSC.Common.Events.CoreEvents;
 
+/// <summary>
+/// Events fired for changes to maps.
+/// </summary>
 public enum MapEvent
 {
+    /// <summary>
+    /// When a map was added to the server.
+    /// </summary>
     MapAdded,
+    
+    /// <summary>
+    /// When a map was updated.
+    /// </summary>
     MapUpdated,
+    
+    /// <summary>
+    /// When a map as removed.
+    /// </summary>
     MapRemoved,
 }

--- a/src/EvoSC.Common/Events/CoreEvents/MapEvent.cs
+++ b/src/EvoSC.Common/Events/CoreEvents/MapEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace EvoSC.Common.Events.CoreEvents;
+
+public enum MapEvent
+{
+    MapAdded,
+    MapUpdated,
+    MapRemoved,
+}

--- a/src/EvoSC.Common/Events/CoreEvents/MatchSettingsEvent.cs
+++ b/src/EvoSC.Common/Events/CoreEvents/MatchSettingsEvent.cs
@@ -1,0 +1,10 @@
+﻿namespace EvoSC.Common.Events.CoreEvents;
+
+public enum MatchSettingsEvent
+{
+    ScriptSettingsChanged,
+    MatchSettingsLoaded,
+    MatchSettingsCreated,
+    MatchSettingsUpdated,
+    MatchSettingsDeleted
+}

--- a/src/EvoSC.Common/Events/CoreEvents/MatchSettingsEvent.cs
+++ b/src/EvoSC.Common/Events/CoreEvents/MatchSettingsEvent.cs
@@ -1,10 +1,32 @@
 ﻿namespace EvoSC.Common.Events.CoreEvents;
 
+/// <summary>
+/// Events for changes to match settings.
+/// </summary>
 public enum MatchSettingsEvent
 {
+    /// <summary>
+    /// Triggered when the script settings has been changed on the server.
+    /// </summary>
     ScriptSettingsChanged,
+    
+    /// <summary>
+    /// Triggered when a matchsettings is loaded.
+    /// </summary>
     MatchSettingsLoaded,
+    
+    /// <summary>
+    /// Triggered when a new matchsettings has been created.
+    /// </summary>
     MatchSettingsCreated,
+    
+    /// <summary>
+    /// Triggered when an existing matchsettings was updated.
+    /// </summary>
     MatchSettingsUpdated,
+    
+    /// <summary>
+    /// triggered when a matchsettings has been deleted.
+    /// </summary>
     MatchSettingsDeleted
 }

--- a/src/EvoSC.Common/Interfaces/Database/Repository/IMapRepository.cs
+++ b/src/EvoSC.Common/Interfaces/Database/Repository/IMapRepository.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Common.Interfaces.Models;
+﻿using EvoSC.Common.Database.Models.Maps;
+using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Models.Maps;
 
 namespace EvoSC.Common.Interfaces.Database.Repository;
@@ -51,7 +52,7 @@ public interface IMapRepository
     /// <param name="mapId"></param>
     /// <param name="map"></param>
     /// <returns></returns>
-    public Task<IMap> UpdateMapAsync(long mapId, MapMetadata map);
+    public Task<IMap> UpdateMapAsync(DbMap map);
     
     /// <summary>
     /// Removes a map from the database.

--- a/src/EvoSC.Common/Interfaces/Services/IMatchSettingsMaplistUpdateService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IMatchSettingsMaplistUpdateService.cs
@@ -1,0 +1,3 @@
+﻿namespace EvoSC.Common.Interfaces.Services;
+
+public interface IMatchSettingsMaplistUpdateService;

--- a/src/EvoSC.Common/Interfaces/Services/IMatchSettingsService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IMatchSettingsService.cs
@@ -103,4 +103,24 @@ public interface IMatchSettingsService
     /// </summary>
     /// <returns></returns>
     public Task<DefaultModeScriptName> GetCurrentModeAsync();
+    
+    /// <summary>
+    /// Get the matchsettings that is currently loaded
+    /// onto the server.
+    /// </summary>
+    /// <returns></returns>
+    public IMatchSettings GetCurrentMatchSettingsAsync();
+    
+    /// <summary>
+    /// Re-load the current match settings.
+    /// </summary>
+    /// <returns></returns>
+    public Task ReloadCurrentMatchSettingsAsync();
+    
+    /// <summary>
+    /// Edit the current match settings.
+    /// </summary>
+    /// <param name="builderAction">Fluent builder for editing the contents.</param>
+    /// <returns></returns>
+    public Task EditCurrentMatchSettingsAsync(Action<MatchSettingsBuilder> builderAction);
 }

--- a/src/EvoSC.Common/Interfaces/Services/IMatchSettingsService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IMatchSettingsService.cs
@@ -109,7 +109,7 @@ public interface IMatchSettingsService
     /// onto the server.
     /// </summary>
     /// <returns></returns>
-    public IMatchSettings GetCurrentMatchSettingsAsync();
+    public IMatchSettings GetCurrentMatchSettings();
     
     /// <summary>
     /// Re-load the current match settings.

--- a/src/EvoSC.Common/Interfaces/Services/IMatchSettingsTrackerService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IMatchSettingsTrackerService.cs
@@ -1,0 +1,18 @@
+﻿using EvoSC.Common.Interfaces.Util;
+
+namespace EvoSC.Common.Interfaces.Services;
+
+public interface IMatchSettingsTrackerService
+{
+    /// <summary>
+    /// The current matchsettings that is loaded on the server.
+    /// </summary>
+    public IMatchSettings CurrentMatchSettings { get; }
+    
+    /// <summary>
+    /// Set the current matchsettings to the default one defined
+    /// in the config.
+    /// </summary>
+    /// <returns></returns>
+    public Task SetDefaultMatchSettingsAsync();
+}

--- a/src/EvoSC.Common/Interfaces/Util/IMatchSettings.cs
+++ b/src/EvoSC.Common/Interfaces/Util/IMatchSettings.cs
@@ -30,5 +30,9 @@ public interface IMatchSettings
     /// </summary>
     public int StartIndex { get; set; }
     
+    /// <summary>
+    /// The name of the matchsettings, typically the same
+    /// as the file name without the .txt extension.
+    /// </summary>
     public string Name { get; init; }
 }

--- a/src/EvoSC.Common/Interfaces/Util/IMatchSettings.cs
+++ b/src/EvoSC.Common/Interfaces/Util/IMatchSettings.cs
@@ -29,4 +29,6 @@ public interface IMatchSettings
     /// The index to start in the map list.
     /// </summary>
     public int StartIndex { get; set; }
+    
+    public string Name { get; init; }
 }

--- a/src/EvoSC.Common/Services/CommonServiceExtensions.cs
+++ b/src/EvoSC.Common/Services/CommonServiceExtensions.cs
@@ -18,6 +18,7 @@ public static class CommonServiceExtensions
         services.Register<IMapService, MapService>(Lifestyle.Transient);
         services.RegisterSingleton<IPlayerCacheService, PlayerCacheService>();
         services.Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient);
+        services.RegisterSingleton<IMatchSettingsTrackerService, MatchSettingsTrackerService>();
         services.Register<IAuditService, AuditService>(Lifestyle.Transient);
         services.RegisterSingleton<IServiceContainerManager, ServiceContainerManager>();
         

--- a/src/EvoSC.Common/Services/CommonServiceExtensions.cs
+++ b/src/EvoSC.Common/Services/CommonServiceExtensions.cs
@@ -7,27 +7,6 @@ namespace EvoSC.Common.Services;
 
 public static class CommonServiceExtensions
 {
-    /// <summary>
-    /// Add the common core services to the service container.
-    /// </summary>
-    /// <param name="services"></param>
-    /// <returns></returns>
-    public static Container AddEvoScCommonServices(this Container services)
-    {
-        services.Register<IPlayerManagerService, PlayerManagerService>(Lifestyle.Transient);
-        services.Register<IMapService, MapService>(Lifestyle.Transient);
-        services.RegisterSingleton<IPlayerCacheService, PlayerCacheService>();
-        
-        services.Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient);
-        services.RegisterSingleton<IMatchSettingsTrackerService, MatchSettingsTrackerService>();
-        services.RegisterSingleton<IMatchSettingsMaplistUpdateService, MatchSettingsMaplistUpdateService>();
-        
-        services.Register<IAuditService, AuditService>(Lifestyle.Transient);
-        services.RegisterSingleton<IServiceContainerManager, ServiceContainerManager>();
-        
-        return services;
-    }
-
     public static Container AddEvoScCommonScopedServices(this Container services)
     {
         services.Register<IContextService, ContextService>(Lifestyle.Scoped);

--- a/src/EvoSC.Common/Services/CommonServiceExtensions.cs
+++ b/src/EvoSC.Common/Services/CommonServiceExtensions.cs
@@ -17,8 +17,11 @@ public static class CommonServiceExtensions
         services.Register<IPlayerManagerService, PlayerManagerService>(Lifestyle.Transient);
         services.Register<IMapService, MapService>(Lifestyle.Transient);
         services.RegisterSingleton<IPlayerCacheService, PlayerCacheService>();
+        
         services.Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient);
         services.RegisterSingleton<IMatchSettingsTrackerService, MatchSettingsTrackerService>();
+        services.RegisterSingleton<IMatchSettingsMaplistUpdateService, MatchSettingsMaplistUpdateService>();
+        
         services.Register<IAuditService, AuditService>(Lifestyle.Transient);
         services.RegisterSingleton<IServiceContainerManager, ServiceContainerManager>();
         

--- a/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
@@ -1,12 +1,9 @@
-﻿using EvoSC.Common.Database.Models.Maps;
-using EvoSC.Common.Events;
+﻿using EvoSC.Common.Events;
 using EvoSC.Common.Events.Arguments;
-using EvoSC.Common.Events.Arguments.MatchSettings;
 using EvoSC.Common.Events.CoreEvents;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
-using EvoSC.Common.Interfaces.Util;
 
 namespace EvoSC.Common.Services;
 
@@ -23,7 +20,7 @@ public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateServ
         events.Subscribe(s => s
             .WithEvent(MapEvent.MapAdded)
             .WithInstance(this)
-            .WithInstanceClass<MatchSettingsTrackerService>()
+            .WithInstanceClass<MatchSettingsMaplistUpdateService>()
             .WithHandlerMethod<MapEventArgs>(OnMapAdded)
             .WithPriority(EventPriority.High)
         );
@@ -31,7 +28,7 @@ public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateServ
         events.Subscribe(s => s
             .WithEvent(MapEvent.MapUpdated)
             .WithInstance(this)
-            .WithInstanceClass<MatchSettingsTrackerService>()
+            .WithInstanceClass<MatchSettingsMaplistUpdateService>()
             .WithHandlerMethod<MapUpdatedEventArgs>(OnMapUpdated)
             .WithPriority(EventPriority.High)
         );

--- a/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
@@ -21,7 +21,7 @@ public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateServ
             .WithEvent(MapEvent.MapAdded)
             .WithInstance(this)
             .WithInstanceClass<MatchSettingsMaplistUpdateService>()
-            .WithHandlerMethod<MapEventArgs>(OnMapAdded)
+            .WithHandlerMethod<MapEventArgs>(OnMapAddedAsync)
             .WithPriority(EventPriority.High)
         );
         
@@ -29,12 +29,12 @@ public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateServ
             .WithEvent(MapEvent.MapUpdated)
             .WithInstance(this)
             .WithInstanceClass<MatchSettingsMaplistUpdateService>()
-            .WithHandlerMethod<MapUpdatedEventArgs>(OnMapUpdated)
+            .WithHandlerMethod<MapUpdatedEventArgs>(OnMapUpdatedAsync)
             .WithPriority(EventPriority.High)
         );
     }
 
-    private async Task OnMapUpdated(object sender, MapUpdatedEventArgs e)
+    private async Task OnMapUpdatedAsync(object sender, MapUpdatedEventArgs e)
     {
         await _matchSettingsService.EditCurrentMatchSettingsAsync(ms =>
         {
@@ -45,7 +45,7 @@ public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateServ
         await AddMapToLiveMapListAsync(e.Map);
     }
 
-    private async Task OnMapAdded(object sender, MapEventArgs e)
+    private async Task OnMapAddedAsync(object sender, MapEventArgs e)
     {
         await _matchSettingsService.EditCurrentMatchSettingsAsync(ms => ms.AddMap(e.Map));
         await AddMapToLiveMapListAsync(e.Map);

--- a/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsMaplistUpdateService.cs
@@ -1,0 +1,46 @@
+﻿using EvoSC.Common.Events;
+using EvoSC.Common.Events.Arguments;
+using EvoSC.Common.Events.Arguments.MatchSettings;
+using EvoSC.Common.Events.CoreEvents;
+using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util;
+
+namespace EvoSC.Common.Services;
+
+public class MatchSettingsMaplistUpdateService : IMatchSettingsMaplistUpdateService
+{
+    private readonly IMatchSettingsService _matchSettingsService;
+    
+    public MatchSettingsMaplistUpdateService(EventManager events, IMatchSettingsService matchSettingsService)
+    {
+        _matchSettingsService = matchSettingsService;
+        
+        events.Subscribe(s => s
+            .WithEvent(MapEvent.MapAdded)
+            .WithInstance(this)
+            .WithInstanceClass<MatchSettingsTrackerService>()
+            .WithHandlerMethod<MapEventArgs>(OnMapAdded)
+            .WithPriority(EventPriority.High)
+        );
+        
+        events.Subscribe(s => s
+            .WithEvent(MapEvent.MapUpdated)
+            .WithInstance(this)
+            .WithInstanceClass<MatchSettingsTrackerService>()
+            .WithHandlerMethod<MapUpdatedEventArgs>(OnMapUpdated)
+            .WithPriority(EventPriority.High)
+        );
+    }
+
+    private Task OnMapUpdated(object sender, MapUpdatedEventArgs e) =>
+        _matchSettingsService.EditCurrentMatchSettingsAsync(ms =>
+        {
+            ms.Maps.Remove(e.OldMap);
+            ms.AddMap(e.Map);
+        });
+
+    private Task OnMapAdded(object sender, MapEventArgs e) =>
+        _matchSettingsService.EditCurrentMatchSettingsAsync(ms => ms.AddMap(e.Map));
+
+}

--- a/src/EvoSC.Common/Services/MatchSettingsService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsService.cs
@@ -1,5 +1,4 @@
-﻿using EvoSC.Common.Config.Models;
-using EvoSC.Common.Events.Arguments.MatchSettings;
+﻿using EvoSC.Common.Events.Arguments.MatchSettings;
 using EvoSC.Common.Events.CoreEvents;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Models;
@@ -15,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Common.Services;
 
-public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerClient server, IMapService mapService, IEventManager events)
+public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerClient server, IMapService mapService, IEventManager events, IMatchSettingsTrackerService matchSettingsTrackerService)
     : IMatchSettingsService
 {
     public async Task SetCurrentScriptSettingsAsync(Action<Dictionary<string, object>> settingsAction)
@@ -140,6 +139,17 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
     {
         var scriptName = await GetCurrentScriptNameAsync();
         return scriptName.ToEnumValue<DefaultModeScriptName>() ?? DefaultModeScriptName.Unknown;
+    }
+
+    public IMatchSettings GetCurrentMatchSettingsAsync() => matchSettingsTrackerService.CurrentMatchSettings;
+    public Task ReloadCurrentMatchSettingsAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task EditCurrentMatchSettingsAsync(Action<MatchSettingsBuilder> builderAction)
+    {
+        throw new NotImplementedException();
     }
 
     private async Task<string> GetFilePathAsync(string name)

--- a/src/EvoSC.Common/Services/MatchSettingsService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsService.cs
@@ -141,16 +141,12 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
         return scriptName.ToEnumValue<DefaultModeScriptName>() ?? DefaultModeScriptName.Unknown;
     }
 
-    public IMatchSettings GetCurrentMatchSettingsAsync() => matchSettingsTrackerService.CurrentMatchSettings;
-    public Task ReloadCurrentMatchSettingsAsync()
-    {
-        throw new NotImplementedException();
-    }
+    public IMatchSettings GetCurrentMatchSettings() => matchSettingsTrackerService.CurrentMatchSettings;
 
-    public Task EditCurrentMatchSettingsAsync(Action<MatchSettingsBuilder> builderAction)
-    {
-        throw new NotImplementedException();
-    }
+    public Task ReloadCurrentMatchSettingsAsync() => LoadMatchSettingsAsync(GetCurrentMatchSettings().Name);
+
+    public Task EditCurrentMatchSettingsAsync(Action<MatchSettingsBuilder> builderAction) =>
+        EditMatchSettingsAsync(GetCurrentMatchSettings().Name, builderAction);
 
     private async Task<string> GetFilePathAsync(string name)
     {

--- a/src/EvoSC.Common/Services/MatchSettingsService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsService.cs
@@ -1,4 +1,6 @@
 ﻿using EvoSC.Common.Config.Models;
+using EvoSC.Common.Events.Arguments.MatchSettings;
+using EvoSC.Common.Events.CoreEvents;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
@@ -13,7 +15,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Common.Services;
 
-public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerClient server, IEvoScBaseConfig config, IMapService mapService)
+public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerClient server, IMapService mapService, IEventManager events)
     : IMatchSettingsService
 {
     public async Task SetCurrentScriptSettingsAsync(Action<Dictionary<string, object>> settingsAction)
@@ -27,6 +29,10 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
         
         settingsAction(settings);
         await server.Remote.SetModeScriptSettingsAsync(settings);
+        await events.RaiseAsync(MatchSettingsEvent.ScriptSettingsChanged, new ScriptSettingsChangedEventArgs
+        {
+            NewScriptSettings = settings 
+        });
     }
 
     public Task SetCurrentScriptSettingsAsync(IMatchSettings matchSettings) => SetCurrentScriptSettingsAsync(settings =>
@@ -52,6 +58,16 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
             var file = Path.GetFileName($"{name}.txt");
             await server.Remote.LoadMatchSettingsAsync($"MatchSettings/{file}");
 
+            try
+            {
+                var ms = await GetMatchSettingsAsync(name);
+                await events.RaiseAsync(MatchSettingsEvent.MatchSettingsLoaded, new MatchSettingsEventArgs { MatchSettings = ms });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to get matchsettings of name '{Name}'", name);
+            }
+
             if (skipMap)
             {
                 await server.Remote.NextMapAsync();
@@ -70,12 +86,14 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
         }
     }
 
-    public Task<IMatchSettings> CreateMatchSettingsAsync(string name, Action<MatchSettingsBuilder> matchSettings)
+    public async Task<IMatchSettings> CreateMatchSettingsAsync(string name, Action<MatchSettingsBuilder> matchSettings)
     {
         var builder = new MatchSettingsBuilder();
         matchSettings(builder);
 
-        return SaveMatchSettingsAsync(name, builder);
+        var ms = await SaveMatchSettingsAsync(name, builder);
+        await events.RaiseAsync(MatchSettingsEvent.MatchSettingsCreated, new MatchSettingsEventArgs { MatchSettings = ms });
+        return ms;
     }
 
     public async Task<IMatchSettings> GetMatchSettingsAsync(string name)
@@ -83,7 +101,7 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
         var filePath = await GetFilePathAsync(name);
         
         var contents = await File.ReadAllTextAsync(filePath);
-        return await MatchSettingsXmlParser.ParseAsync(contents);
+        return await MatchSettingsXmlParser.ParseAsync(name, contents);
     }
 
     public async Task<IEnumerable<IMap>> GetCurrentMapListAsync()
@@ -99,13 +117,17 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
         var currentMatchSettings = await GetMatchSettingsAsync(name);
         var builder = new MatchSettingsBuilder(currentMatchSettings);
         builderAction(builder);
-        await SaveMatchSettingsAsync(name, builder);
+        var newMatchsettings = await SaveMatchSettingsAsync(name, builder);
+        
+        await events.RaiseAsync(MatchSettingsEvent.MatchSettingsUpdated, new MatchSettingsEventArgs { MatchSettings = newMatchsettings });
     }
 
     public async Task DeleteMatchSettingsAsync(string name)
     {
+        var ms = await GetMatchSettingsAsync(name);
         var filePath = await GetFilePathAsync(name);
         File.Delete(filePath);
+        await events.RaiseAsync(MatchSettingsEvent.MatchSettingsDeleted, new MatchSettingsEventArgs { MatchSettings = ms });
     }
 
     public async Task<string> GetCurrentScriptNameAsync()

--- a/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
@@ -1,10 +1,12 @@
 ﻿using EvoSC.Common.Config.Models;
 using EvoSC.Common.Events;
+using EvoSC.Common.Events.Arguments;
 using EvoSC.Common.Events.Arguments.MatchSettings;
 using EvoSC.Common.Events.CoreEvents;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Services;
 using EvoSC.Common.Interfaces.Util;
+using MapEventArgs = EvoSC.Common.Remote.EventArgsModels.MapEventArgs;
 
 namespace EvoSC.Common.Services;
 

--- a/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
@@ -1,0 +1,64 @@
+﻿using EvoSC.Common.Config.Models;
+using EvoSC.Common.Events;
+using EvoSC.Common.Events.Arguments.MatchSettings;
+using EvoSC.Common.Events.CoreEvents;
+using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Common.Interfaces.Util;
+
+namespace EvoSC.Common.Services;
+
+public class MatchSettingsTrackerService : IMatchSettingsTrackerService
+{
+    private IMatchSettings _currentMatchSettings;
+    private readonly object _currentMatchSettingsLock = new();
+
+    private readonly IEvoSCApplication _app;
+    
+    public MatchSettingsTrackerService(EventManager events, IEvoSCApplication app)
+    {
+        _app = app;
+        
+        events.Subscribe(s => s
+            .WithEvent(MatchSettingsEvent.MatchSettingsLoaded)
+            .WithInstance(this)
+            .WithInstanceClass<MatchSettingsTrackerService>()
+            .WithHandlerMethod<MatchSettingsEventArgs>(OnMatchSettingsLoaded)
+            .WithPriority(EventPriority.High)
+        );
+    }
+
+    private Task OnMatchSettingsLoaded(object sender, MatchSettingsEventArgs e)
+    {
+        lock (_currentMatchSettingsLock)
+        {
+            _currentMatchSettings = e.MatchSettings;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public IMatchSettings CurrentMatchSettings
+    {
+        get
+        {
+            lock (_currentMatchSettingsLock)
+            {
+                return _currentMatchSettings;
+            }
+        }
+    }
+
+    public async Task SetDefaultMatchSettingsAsync()
+    {
+        var evoscConfig = _app.Services.GetInstance<IEvoScBaseConfig>();
+        var msService = _app.Services.GetInstance<IMatchSettingsService>();
+
+        var ms = await msService.GetMatchSettingsAsync(evoscConfig.Path.DefaultMatchSettings);
+
+        lock (_currentMatchSettingsLock)
+        {
+            _currentMatchSettings = ms;
+        }
+    }
+}

--- a/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
@@ -17,7 +17,7 @@ public class MatchSettingsTrackerService : IMatchSettingsTrackerService
 
     private readonly IEvoSCApplication _app;
     
-    public MatchSettingsTrackerService(EventManager events, IEvoSCApplication app)
+    public MatchSettingsTrackerService(IEventManager events, IEvoSCApplication app)
     {
         _app = app;
         

--- a/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsTrackerService.cs
@@ -1,12 +1,10 @@
 ﻿using EvoSC.Common.Config.Models;
 using EvoSC.Common.Events;
-using EvoSC.Common.Events.Arguments;
 using EvoSC.Common.Events.Arguments.MatchSettings;
 using EvoSC.Common.Events.CoreEvents;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Services;
 using EvoSC.Common.Interfaces.Util;
-using MapEventArgs = EvoSC.Common.Remote.EventArgsModels.MapEventArgs;
 
 namespace EvoSC.Common.Services;
 

--- a/src/EvoSC.Common/Util/MatchSettings/Builders/MatchSettingsBuilder.cs
+++ b/src/EvoSC.Common/Util/MatchSettings/Builders/MatchSettingsBuilder.cs
@@ -19,6 +19,8 @@ public class MatchSettingsBuilder
     private List<IMap> _maps = new();
     private int _startIndex;
 
+    public List<IMap> Maps => _maps;
+    
     public MatchSettingsBuilder()
     {
     }

--- a/src/EvoSC.Common/Util/MatchSettings/MatchSettingsXmlParser.cs
+++ b/src/EvoSC.Common/Util/MatchSettings/MatchSettingsXmlParser.cs
@@ -25,16 +25,18 @@ public static class MatchSettingsXmlParser
     /// <summary>
     /// Parse a string containing a XML document.
     /// </summary>
+    /// <param name="name">The name of the matchsettings.</param>
     /// <param name="xml">The XML document to parse.</param>
     /// <returns></returns>
-    public static Task<IMatchSettings> ParseAsync(string xml) => ParseAsync(XDocument.Parse(xml));
+    public static Task<IMatchSettings> ParseAsync(string name, string xml) => ParseAsync(name, XDocument.Parse(xml));
 
     /// <summary>
     /// Parse a XML document.
     /// </summary>
+    /// <param name="name">The name of the matchsettings</param>
     /// <param name="document">The XML document to parse.</param>
     /// <returns></returns>
-    public static async Task<IMatchSettings> ParseAsync(XDocument document)
+    public static async Task<IMatchSettings> ParseAsync(string name, XDocument document)
     {
         var playlistElement = document.Elements("playlist").First();
 
@@ -50,7 +52,8 @@ public static class MatchSettingsXmlParser
             Filter = filter,
             ModeScriptSettings = scriptSettings,
             Maps = maps,
-            StartIndex = startIndex
+            StartIndex = startIndex,
+            Name = name
         };
     }
 

--- a/src/EvoSC.Common/Util/MatchSettings/Models/MatchSettingsXmlSerializer.cs
+++ b/src/EvoSC.Common/Util/MatchSettings/Models/MatchSettingsXmlSerializer.cs
@@ -14,6 +14,7 @@ public class MatchSettingsXmlSerializer : IMatchSettings
     public Dictionary<string, ModeScriptSettingInfo>? ModeScriptSettings { get; set; }
     public List<IMap>? Maps { get; set; }
     public int StartIndex { get; set; }
+    public string Name { get; init; }
 
     /// <summary>
     /// Convert the match settings to an XML document.

--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -98,7 +98,7 @@ public static class ApplicationSetup
                 .GetInstance<IEventManager>()
             )
 
-            .AsyncAction("InitializeCaches", InitializeCachesAsync)
+            .AsyncAction("InitializeCaches", InitializeCachesAndTrackers)
 
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                 .GetInstance<IManialinkInteractionHandler>()
@@ -207,11 +207,12 @@ public static class ApplicationSetup
     /// initialization methods to make them ready.
     /// </summary>
     /// <param name="s"></param>
-    private static async Task InitializeCachesAsync(ServicesBuilder s)
+    private static async Task InitializeCachesAndTrackers(ServicesBuilder s)
     {
         var msTrackerService = s.GetInstance<IMatchSettingsTrackerService>();
         await msTrackerService.SetDefaultMatchSettingsAsync();
         
         s.GetInstance<IPlayerCacheService>();
+        s.GetInstance<IMatchSettingsMaplistUpdateService>();
     }
 }

--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -101,7 +101,7 @@ public static class ApplicationSetup
                 .GetInstance<IEventManager>()
             )
 
-            .AsyncAction("InitializeCaches", InitializeCachesAndTrackers)
+            .AsyncAction("InitializeCaches", InitializeCachesAndTrackersAsync)
 
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                 .GetInstance<IManialinkInteractionHandler>()
@@ -210,7 +210,7 @@ public static class ApplicationSetup
     /// initialization methods to make them ready.
     /// </summary>
     /// <param name="s"></param>
-    private static async Task InitializeCachesAndTrackers(ServicesBuilder s)
+    private static async Task InitializeCachesAndTrackersAsync(ServicesBuilder s)
     {
         var msTrackerService = s.GetInstance<IMatchSettingsTrackerService>();
         await msTrackerService.SetDefaultMatchSettingsAsync();

--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -98,9 +98,7 @@ public static class ApplicationSetup
                 .GetInstance<IEventManager>()
             )
 
-            .Action("ActionInitializePlayerCache", s => s
-                .GetInstance<IPlayerCacheService>()
-            )
+            .AsyncAction("InitializeCaches", InitializeCachesAsync)
 
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                 .GetInstance<IManialinkInteractionHandler>()
@@ -202,5 +200,18 @@ public static class ApplicationSetup
         s.GetInstance<IServerCallbackHandler>();
         s.GetInstance<IRemoteChatRouter>();
         await serverClient.StartAsync(CancellationToken.None);
+    }
+    
+    /// <summary>
+    /// Creates the singleton instances of caches and runs
+    /// initialization methods to make them ready.
+    /// </summary>
+    /// <param name="s"></param>
+    private static async Task InitializeCachesAsync(ServicesBuilder s)
+    {
+        var msTrackerService = s.GetInstance<IMatchSettingsTrackerService>();
+        await msTrackerService.SetDefaultMatchSettingsAsync();
+        
+        s.GetInstance<IPlayerCacheService>();
     }
 }

--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -61,9 +61,12 @@ public static class ApplicationSetup
                 .RegisterSingleton<IPlayerCacheService, PlayerCacheService>()
             )
 
-            .Services(AppFeature.MatchSettings, s => s
-                .Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient)
-            )
+            .Services(AppFeature.MatchSettings, s =>
+            {
+                s.Register<IMatchSettingsService, MatchSettingsService>(Lifestyle.Transient);
+                s.RegisterSingleton<IMatchSettingsTrackerService, MatchSettingsTrackerService>();
+                s.RegisterSingleton<IMatchSettingsMaplistUpdateService, MatchSettingsMaplistUpdateService>();
+            })
 
             .Services(AppFeature.Auditing, s => s
                 .Register<IAuditService, AuditService>(Lifestyle.Transient)

--- a/tests/EvoSC.Common.Tests/Database/MapRepositoryTests.cs
+++ b/tests/EvoSC.Common.Tests/Database/MapRepositoryTests.cs
@@ -60,17 +60,14 @@ public class MapRepositoryTests
         var (repo, dbFactory) = CreateNewRepository();
         var addedMap = await AddTestMap(dbFactory);
 
-        await repo.UpdateMapAsync(addedMap.Id,
-            new MapMetadata
-            {
-                MapUid = "TestMapUid1",
-                MapName = "MyMap1",
-                AuthorId = "",
-                AuthorName = "",
-                ExternalId = "MyExternalMapId1",
-                ExternalVersion = new DateTime(2, 2, 3, 4, 5, 6, 7),
-                ExternalMapProvider = MapProviders.TrackmaniaIo
-            });
+        await repo.UpdateMapAsync(new DbMap(addedMap)
+        {
+            Uid = "TestMapUid1",
+            Name = "MyMap1",
+            ExternalId = "MyExternalMapId1",
+            ExternalVersion = new DateTime(2, 2, 3, 4, 5, 6, 7),
+            ExternalMapProvider = MapProviders.TrackmaniaIo
+        });
         
         var updatedMap = await dbFactory.GetConnection().GetTable<DbMap>().FirstOrDefaultAsync(r => r.Id == addedMap.Id);
         

--- a/tests/EvoSC.Common.Tests/Services/MapServiceTests.cs
+++ b/tests/EvoSC.Common.Tests/Services/MapServiceTests.cs
@@ -30,6 +30,7 @@ public class MapServiceTests
     private readonly Mock<ILogger<MapService>> _logger = new();
     private readonly Mock<IEvoScBaseConfig> _config = new();
     private readonly Mock<IPlayerManagerService> _playerService = new();
+    private readonly Mock<IEventManager> _eventManager = new();
 
     private readonly (Mock<IServerClient> Client, Mock<IGbxRemoteClient> Remote, Mock<IChatService> Chat)
         _server = Mocking.NewServerClientMock();
@@ -39,7 +40,7 @@ public class MapServiceTests
     public MapServiceTests()
     {
         _mapService = new MapService(_mapRepository.Object, _logger.Object, _config.Object, _playerService.Object,
-            _server.Client.Object);
+            _server.Client.Object, _eventManager.Object);
 
         _server.Remote.Setup(m => m.GetMapInfoAsync(It.IsAny<string>()))
             .Returns(Task.FromResult(new TmMapInfo
@@ -223,7 +224,7 @@ public class MapServiceTests
 
         _mapRepository.Setup(m => m.GetMapByUidAsync(It.IsAny<string>()))
             .Returns(Task.FromResult((IMap?)map));
-        _mapRepository.Setup(m => m.UpdateMapAsync(It.IsAny<long>(), It.IsAny<MapMetadata>()))
+        _mapRepository.Setup(m => m.UpdateMapAsync(It.IsAny<DbMap>()))
             .Returns(Task.FromResult((IMap)map));
         _config.Setup(c => c.Path.Maps).Returns("maps");
         _playerService.Setup(p => p.GetPlayerAsync(It.IsAny<string>())).Returns(Task.FromResult((IPlayer?)player));
@@ -236,53 +237,6 @@ public class MapServiceTests
         Assert.Equal(map.Uid, updatedMap.Uid);
         Assert.Equal(map.Name, updatedMap.Name);
         Assert.Equal(map.AuthorId, updatedMap.Author.Id);
-    }
-
-    [Fact]
-    public async Task Add_Map_With_Same_Version_Throws_DuplicateMapException()
-    {
-        using var testStream = new MemoryStream("whatever"u8.ToArray());
-        var version = new DateTime();
-        var mapMetadata = new MapMetadata
-        {
-            AuthorId = "0efeba8a-9cda-49fa-ab25-35f1d9218c95",
-            AuthorName = "snippen",
-            MapUid = "mapUid",
-            MapName = "snippens track",
-            ExternalId = "",
-            ExternalVersion = version,
-            ExternalMapProvider = MapProviders.ManiaExchange
-        };
-        var mapStream = new MapStream(mapMetadata, testStream);
-        var player = new DbPlayer
-        {
-            Id = 1,
-            UbisoftName = "snippen",
-            AccountId = "0efeba8a-9cda-49fa-ab25-35f1d9218c95",
-            NickName = "snippen",
-            CreatedAt = new DateTime(),
-            UpdatedAt = new DateTime(),
-            LastVisit = new DateTime()
-        };
-        var map = new DbMap
-        {
-            AuthorId = 1,
-            Enabled = true,
-            Id = 123,
-            ExternalId = "1337",
-            Name = "snippens dream",
-            Uid = "Uid",
-            ExternalMapProvider = MapProviders.ManiaExchange,
-            ExternalVersion = version,
-            DbAuthor = player
-        };
-
-        _mapRepository.Setup(m => m.GetMapByUidAsync(It.IsAny<string>()))
-            .Returns(Task.FromResult((IMap?)map));
-        _mapRepository.Setup(m => m.UpdateMapAsync(It.IsAny<long>(), It.IsAny<MapMetadata>()))
-            .Returns(Task.FromResult((IMap)map));
-
-        await Assert.ThrowsAsync<DuplicateMapException>(() => _mapService.AddMapAsync(mapStream));
     }
 
     [Fact]

--- a/tests/EvoSC.Common.Tests/Util/MatchSettings/MatchSettingsXmlParserTests.cs
+++ b/tests/EvoSC.Common.Tests/Util/MatchSettings/MatchSettingsXmlParserTests.cs
@@ -14,7 +14,7 @@ public class MatchSettingsXmlParserTests
     {
         var xml = File.ReadAllText("TestFiles/Util/MatchSettings/matchsettings_with_all_sections.xml");
 
-        var ms = await MatchSettingsXmlParser.ParseAsync(xml);
+        var ms = await MatchSettingsXmlParser.ParseAsync("Test", xml);
         
         Assert.NotNull(ms);
         Assert.NotNull(ms.GameInfos);
@@ -46,6 +46,8 @@ public class MatchSettingsXmlParserTests
         Assert.NotNull(ms.Maps.FirstOrDefault());
         Assert.Equal("MyMap.Map.Gbx", ms.Maps.FirstOrDefault()?.FilePath);
         Assert.Equal("my-ident", ms.Maps.FirstOrDefault()?.Uid);
+        
+        Assert.Equal("Test", ms.Name);
     }
 
     [Fact]
@@ -55,7 +57,7 @@ public class MatchSettingsXmlParserTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
-            await MatchSettingsXmlParser.ParseAsync(xml);
+            await MatchSettingsXmlParser.ParseAsync("Test", xml);
         });
     }
     
@@ -64,7 +66,7 @@ public class MatchSettingsXmlParserTests
     {
         var xml = File.ReadAllText("TestFiles/Util/MatchSettings/matchsettings_for_default_values.xml");
 
-        var ms = await MatchSettingsXmlParser.ParseAsync(xml);
+        var ms = await MatchSettingsXmlParser.ParseAsync("Test", xml);
         
         Assert.NotNull(ms.GameInfos);
         Assert.Equal(10000, ms.GameInfos.ChatTime);


### PR DESCRIPTION
- Add tracking for the current loaded matchsettings to allow adding adding maps to it when using the /addmap command
- Duplicate map error is removed as I believe it serves no purpose for the user. Let the map to always be updated. That also allows manually fixing any issues with the map's information in the database.
- Maps are now automatically added to the matchsettings file of the current loaded matchsettings, as well as added into the live maplist.
- Added serveral core events for map and matchsettings management.