### PR TITLE
Fix wrong theme attribute reference ( fixes #354 )

### DIFF
--- a/src/Modules/RoundRankingModule/Templates/Components/RoundRankingRow.mt
+++ b/src/Modules/RoundRankingModule/Templates/Components/RoundRankingRow.mt
@@ -66,7 +66,7 @@
                             size="{{ height * 1.25 }} {{ height }}"
                             pos="{{ width-4 }}"
                             class='lr-body-highlight'
-                            bgcolor="{{ checkpoint.AccentColor != null ? checkpoint.AccentColor : Theme.UI_RoundRankingModule_Widget_RowBgHighlight }}"
+                            bgcolor="{{ checkpoint.AccentColor != null ? checkpoint.AccentColor : Theme.UI_RoundRankingModule_Widget_Row_Bg_Highlight }}"
                             halign="right"
                     />
                     <label


### PR DESCRIPTION
In line 69 of RoundRankingRow, the underscores for the Row_Bg_Highlight attribute were missing, causing errors in the module for events like Waypoint and GiveUp.