### PR TITLE
Player's server ID in OnlinePlayer

### DIFF
--- a/src/EvoSC.Common/Interfaces/Models/IOnlinePlayer.cs
+++ b/src/EvoSC.Common/Interfaces/Models/IOnlinePlayer.cs
@@ -8,6 +8,11 @@ namespace EvoSC.Common.Interfaces.Models;
 public interface IOnlinePlayer : IPlayer
 {
     /// <summary>
+    /// The player's ID in the current server.
+    /// </summary>
+    public int PlayerServerId { get; }
+    
+    /// <summary>
     /// The current in-game state of the player.
     /// </summary>
     public PlayerState State { get; }

--- a/src/EvoSC.Common/Interfaces/Services/IPlayerManagerService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IPlayerManagerService.cs
@@ -56,6 +56,11 @@ public interface IPlayerManagerService
     /// <param name="player">Information about the player to get.</param>
     /// <returns>Returns an IOnlinePlayer instance of the player.</returns>
     public Task<IOnlinePlayer> GetOnlinePlayerAsync(IPlayer player);
+
+    /// <summary>
+    /// Get a player by their server ID.
+    /// </summary>
+    public IOnlinePlayer? GetOnlinePlayerByServerIdAsync(int playerServerId);
     
     /// <summary>
     /// Update the last visited column of a player in the database.

--- a/src/EvoSC.Common/Models/Players/OnlinePlayer.cs
+++ b/src/EvoSC.Common/Models/Players/OnlinePlayer.cs
@@ -7,6 +7,8 @@ public class OnlinePlayer : IOnlinePlayer
 {
     public long Id { get; init; }
     public string AccountId { get; set; }
+    
+    public int PlayerServerId { get; set; }
     public string NickName { get; set; }
     public string UbisoftName { get; set; }
     public string Zone { get; set; }

--- a/src/EvoSC.Common/Services/PlayerCacheService.cs
+++ b/src/EvoSC.Common/Services/PlayerCacheService.cs
@@ -204,6 +204,7 @@ public class PlayerCacheService : IPlayerCacheService
 
         var onlinePlayer = new OnlinePlayer(player)
         {
+            PlayerServerId = onlinePlayerDetails.PlayerId,
             State = onlinePlayerDetails.GetState(),
             Flags = onlinePlayerInfo.GetFlags(),
             Team = onlinePlayerDetails.TeamId == 0 ? PlayerTeam.Team1 : PlayerTeam.Team2
@@ -285,6 +286,7 @@ public class PlayerCacheService : IPlayerCacheService
 
             var onlinePlayer = new OnlinePlayer(player.Player)
             {
+                PlayerServerId = onlinePlayerDetails.PlayerId,
                 State = onlinePlayerDetails.GetState(),
                 Flags = onlinePlayerInfo.GetFlags(),
                 Team = onlinePlayerDetails.TeamId == 0 ? PlayerTeam.Team1 : PlayerTeam.Team2

--- a/src/EvoSC.Common/Services/PlayerManagerService.cs
+++ b/src/EvoSC.Common/Services/PlayerManagerService.cs
@@ -75,6 +75,9 @@ public class PlayerManagerService(IPlayerRepository playerRepository, IPlayerCac
 
     public Task<IOnlinePlayer> GetOnlinePlayerAsync(IPlayer player) => GetOnlinePlayerAsync(player.AccountId);
 
+    public IOnlinePlayer? GetOnlinePlayerByServerIdAsync(int playerServerId)
+        => playerCache.OnlinePlayers.FirstOrDefault(p => p.PlayerServerId == playerServerId);
+
     public Task UpdateLastVisitAsync(IPlayer player) => playerRepository.UpdateLastVisitAsync(player);
 
     public Task<IEnumerable<IOnlinePlayer>> GetOnlinePlayersAsync() => Task.FromResult(playerCache.OnlinePlayers);


### PR DESCRIPTION
This pull request introduces functionality to track and retrieve players by their server-specific ID (`PlayerServerId`). The changes primarily involve adding a new property to the `IOnlinePlayer` interface and implementing methods to support this functionality in the player management services.

### Enhancements to Player Identification:

* `IOnlinePlayer` (`src/EvoSC.Common/Interfaces/Models/IOnlinePlayer.cs`): Added a new property, `PlayerServerId`, to uniquely identify players on the server.
* `OnlinePlayer` (`src/EvoSC.Common/Models/Players/OnlinePlayer.cs`): Implemented the `PlayerServerId` property in the `OnlinePlayer` class to align with the updated interface.

### Service Updates for Player Retrieval:

* `IPlayerManagerService` (`src/EvoSC.Common/Interfaces/Services/IPlayerManagerService.cs`): Added a new method, `GetOnlinePlayerByServerIdAsync`, to retrieve players by their server ID.
* `PlayerManagerService` (`src/EvoSC.Common/Services/PlayerManagerService.cs`): Implemented the `GetOnlinePlayerByServerIdAsync` method to search the player cache for a matching `PlayerServerId`.

### Integration with Player Cache:

* `PlayerCacheService` (`src/EvoSC.Common/Services/PlayerCacheService.cs`): Updated the `PlayerServerId` property when creating `OnlinePlayer` instances in both the `PlayerJoined` event and the `UpdatePlayerListAsync` method. [[1]](diffhunk://#diff-34a1adc71f3f0d803c88ebade3bbca3845eee33aacfed4d778b4d2a7bad8cc60R207) [[2]](diffhunk://#diff-34a1adc71f3f0d803c88ebade3bbca3845eee33aacfed4d778b4d2a7bad8cc60R289)