### PR TITLE
Implement map change tracking via state event

### DIFF
--- a/src/Modules/MatchTrackerModule/Config/ITrackerSettings.cs
+++ b/src/Modules/MatchTrackerModule/Config/ITrackerSettings.cs
@@ -17,6 +17,10 @@ public interface ITrackerSettings
     [Option(DefaultValue = true),
      Description("Whether to store match state changes immediately instead of waiting until the match ends.")]
     public bool ImmediateStoring { get; set; }
+    
+    [Option(DefaultValue = true),
+    Description("Whether to record the maps that were played on the server.")]
+    public bool RecordMapChanges { get; set; }
 
     [Option(DefaultValue = true), Description("Record end of map states.")]
     public bool RecordEndMap { get; set; }

--- a/src/Modules/MatchTrackerModule/Controllers/MatchTrackerEventController.cs
+++ b/src/Modules/MatchTrackerModule/Controllers/MatchTrackerEventController.cs
@@ -30,6 +30,17 @@ public class MatchTrackerEventController(ITrackerSettings settings, IMatchTracke
         return tracker.BeginMatchAsync();
     }
 
+    [Subscribe(GbxRemoteEvent.BeginMap)]
+    public Task OnBeginMapAsync(object sender, MapEventArgs args)
+    {
+        if (!settings.RecordMapChanges)
+        {
+            return Task.CompletedTask;
+        }
+        
+        return tracker.TrackMapChangeAsync(args);
+    }
+
     [Subscribe(FlowControlEvent.MatchStarted)]
     public Task OnMatchStarted(object sender, EventArgs args)
     {

--- a/src/Modules/MatchTrackerModule/Interfaces/IMatchTracker.cs
+++ b/src/Modules/MatchTrackerModule/Interfaces/IMatchTracker.cs
@@ -11,6 +11,7 @@ public interface IMatchTracker
     public MatchStatus Status { get; }
     
     public Task TrackScoresAsync(ScoresEventArgs scoreArgs);
+    public Task TrackMapChangeAsync(MapEventArgs mapArgs);
     
     public Task<Guid> BeginMatchAsync();
     public Task<IMatchTimeline> EndMatchAsync();

--- a/src/Modules/MatchTrackerModule/Interfaces/Models/IMapMatchState.cs
+++ b/src/Modules/MatchTrackerModule/Interfaces/Models/IMapMatchState.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Modules.Official.MatchTrackerModule.Interfaces.Models;
+
+public interface IMapMatchState : IMatchState
+{
+    public string MapUid { get; }
+}

--- a/src/Modules/MatchTrackerModule/Models/MapMatchState.cs
+++ b/src/Modules/MatchTrackerModule/Models/MapMatchState.cs
@@ -1,0 +1,11 @@
+﻿using EvoSC.Modules.Official.MatchTrackerModule.Interfaces.Models;
+
+namespace EvoSC.Modules.Official.MatchTrackerModule.Models;
+
+public class MapMatchState : IMapMatchState
+{
+    public required Guid TimelineId { get; init; }
+    public required MatchStatus Status { get; init; }
+    public required DateTime Timestamp { get; init; }
+    public required string MapUid { get; init; }
+}

--- a/src/Modules/MatchTrackerModule/Services/MatchTracker.cs
+++ b/src/Modules/MatchTrackerModule/Services/MatchTracker.cs
@@ -114,6 +114,37 @@ public class MatchTracker(ITrackerSettings settings, IPlayerManagerService playe
         }
     }
 
+    public async Task TrackMapChangeAsync(MapEventArgs mapArgs)
+    {
+        if (!IsTracking)
+        {
+            return;
+        }
+        
+        await VerifyTracker();
+
+        IMatchState state;
+        
+        state = new MapMatchState
+        {
+            Status =
+                MatchStatus.Unknown, // FIXME Either we need to assume the match is running when the server map is changed (bad) or we override the status to unknown (also bad).
+            Timestamp = DateTime.UtcNow,
+            TimelineId = _currentTimeline.TimelineId,
+            MapUid = mapArgs.Map.Uid
+        };
+        
+        _currentTimeline.States.Add(state);
+
+        if (settings.ImmediateStoring)
+        {
+            await trackerStore.SaveState(state);
+        }
+        
+        await events.RaiseAsync(MatchTrackerEvent.StateTracked,
+            new MatchStateTrackedEventArgs {Timeline = _currentTimeline, State = state}, this);
+    }
+    
     public async Task<Guid> BeginMatchAsync()
     {
         if (IsTracking)

--- a/src/Modules/MatchTrackerModule/Services/MatchTracker.cs
+++ b/src/Modules/MatchTrackerModule/Services/MatchTracker.cs
@@ -128,7 +128,7 @@ public class MatchTracker(ITrackerSettings settings, IPlayerManagerService playe
         state = new MapMatchState
         {
             Status =
-                MatchStatus.Unknown, // FIXME Either we need to assume the match is running when the server map is changed (bad) or we override the status to unknown (also bad).
+                MatchStatus.Running,
             Timestamp = DateTime.UtcNow,
             TimelineId = _currentTimeline.TimelineId,
             MapUid = mapArgs.Map.Uid


### PR DESCRIPTION
This implements tracking which maps were played during a match via adding a new `MapMatchState` event based on `GbxRemoteEvent.BeginMap`.

Since this event is supposed to implement the `IMatchState` interface, it also needs to specify the current match status with the event. However, since this information cannot be inferred from the event itself, it is currently set to `Unknown`, which could cause side effects in other programs that do not expect the match state to differ from the usual cycle at any point in time. See src/Modules/MatchTrackerModule/Services/MatchTracker.cs at line 131.