### PR TITLE
Initialize gbx remote before dependent modules (#351)

### DIFF
--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -97,7 +97,9 @@ public static class ApplicationSetup
             .Action("ActionInitializeEventManager", s => s
                 .GetInstance<IEventManager>()
             )
-
+                
+            .AsyncAction("InitializeGbxRemoteConnection", SetupGbxRemoteConnectionAsync)
+                
             .Action("ActionInitializePlayerCache", s => s
                 .GetInstance<IPlayerCacheService>()
             )
@@ -105,9 +107,7 @@ public static class ApplicationSetup
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                 .GetInstance<IManialinkInteractionHandler>()
             )
-
-            .AsyncAction("InitializeGbxRemoteConnection", SetupGbxRemoteConnectionAsync)
-
+                
             .AsyncAction("ActionEnableModules", EnableModulesAsync)
 
             .AsyncAction("ActionInitializeTemplates", InitializeTemplatesAsync, "Manialinks");


### PR DESCRIPTION
Some modules call remote methods during initialization. However, previously the GbxRemoteClient was not yet initialized leading to NullPointerExceptions.