### PR TITLE
Revert "Initialize gbx remote before dependent modules (#351)"

### DIFF
--- a/src/EvoSC/ApplicationSetup.cs
+++ b/src/EvoSC/ApplicationSetup.cs
@@ -97,9 +97,7 @@ public static class ApplicationSetup
             .Action("ActionInitializeEventManager", s => s
                 .GetInstance<IEventManager>()
             )
-                
-            .AsyncAction("InitializeGbxRemoteConnection", SetupGbxRemoteConnectionAsync)
-                
+
             .Action("ActionInitializePlayerCache", s => s
                 .GetInstance<IPlayerCacheService>()
             )
@@ -107,7 +105,9 @@ public static class ApplicationSetup
             .Action("ActionInitializeManialinkInteractionHandler", s => s
                 .GetInstance<IManialinkInteractionHandler>()
             )
-                
+
+            .AsyncAction("InitializeGbxRemoteConnection", SetupGbxRemoteConnectionAsync)
+
             .AsyncAction("ActionEnableModules", EnableModulesAsync)
 
             .AsyncAction("ActionInitializeTemplates", InitializeTemplatesAsync, "Manialinks");


### PR DESCRIPTION
Reverts EvoEsports/EvoSC-sharp#370