### PR TITLE
Backport generic fixes from private XPEvo branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build EvoSC#
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /source
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN dotnet publish "src/EvoSC/EvoSC.csproj" -r linux-musl-x64 --self-contained true -c Release -o /publish
 
 # Create the image
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine3.20 as create-image
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine3.20 AS create-image
 
 ARG VERSION \
     BUILD_DATE \

--- a/src/EvoSC.Commands/ChatCommandManager.cs
+++ b/src/EvoSC.Commands/ChatCommandManager.cs
@@ -17,6 +17,10 @@ public class ChatCommandManager : IChatCommandManager
     
     private readonly Dictionary<string, IChatCommand> _cmds = new();
     private readonly Dictionary<string, string> _aliasMap = new();
+    private readonly List<string> _ignoredCommands = new()
+    {
+        "/chatformat",
+    };
     private readonly Dictionary<Type, List<IChatCommand>> _controllerCommands = new();
     private readonly IValueReaderManager _valueReader;
 
@@ -176,5 +180,12 @@ public class ChatCommandManager : IChatCommandManager
         }
 
         return null;
+    }
+
+    public bool IsIgnoredCommand(string alias, bool withPrefix)
+    {
+        var lookupName = (withPrefix ? CommandPrefix : "") + alias;
+        
+        return _ignoredCommands.Contains(lookupName);
     }
 }

--- a/src/EvoSC.Commands/Interfaces/IChatCommandManager.cs
+++ b/src/EvoSC.Commands/Interfaces/IChatCommandManager.cs
@@ -35,4 +35,11 @@ public interface IChatCommandManager : IControllerActionRegistry
     /// <param name="withPrefix">Whether to include prefix in the name.</param>
     /// <returns></returns>
     public IChatCommand FindCommand(string alias, bool withPrefix);
+    /// <summary>
+    /// Check if command is in ignored list.
+    /// </summary>
+    /// <param name="alias">Name or alias of the command to check.</param>
+    /// <param name="withPrefix">Whether to include prefix in the name.</param>
+    /// <returns></returns>
+    public Boolean IsIgnoredCommand(string alias, bool withPrefix);
 }

--- a/src/EvoSC.Commands/Interfaces/IParserResult.cs
+++ b/src/EvoSC.Commands/Interfaces/IParserResult.cs
@@ -33,4 +33,9 @@ public interface IParserResult
     /// The alias that was used to execute this command.
     /// </summary>
     public string AliasUsed { get; }
+    
+    /// <summary>
+    /// Whether the command was ignored or not.
+    /// </summary>
+    public bool IsIgnored { get; }
 }

--- a/src/EvoSC.Commands/Middleware/CommandsMiddleware.cs
+++ b/src/EvoSC.Commands/Middleware/CommandsMiddleware.cs
@@ -122,6 +122,10 @@ public class CommandsMiddleware(ActionDelegate next, ILogger<CommandsMiddleware>
             {
                 await HandleUserErrorsAsync(parserResult, context.Author);
             }
+            else if (parserResult.IsIgnored)
+            {
+                logger.LogDebug("Command '{Name}' is ignored", context.MessageText);
+            }
             else
             {
                 logger.LogError(

--- a/src/EvoSC.Commands/Parser/ChatCommandParser.cs
+++ b/src/EvoSC.Commands/Parser/ChatCommandParser.cs
@@ -19,6 +19,12 @@ public class ChatCommandParser(IChatCommandManager cmdManager)
             }
 
             var cmdAlias = parts[0];
+
+            if (cmdManager.IsIgnoredCommand(cmdAlias, false))
+            {
+                return new ParserResult {Command = null, Arguments = null, Success = false, IsIntended = false, IsIgnored = true};
+            }
+            
             bool intendedCommand = cmdAlias.StartsWith(CommandPrefix, StringComparison.Ordinal);
             var cmd = cmdManager.FindCommand(cmdAlias, false);
 

--- a/src/EvoSC.Commands/Parser/ParserResult.cs
+++ b/src/EvoSC.Commands/Parser/ParserResult.cs
@@ -10,4 +10,5 @@ public class ParserResult : IParserResult
     public Exception Exception { get; init; }
     public required bool IsIntended { get; init; }
     public string AliasUsed { get; init; }
+    public bool IsIgnored { get; init; }
 }

--- a/src/EvoSC.Common/Database/Migrations/202210100826_AddPlayersTable.cs
+++ b/src/EvoSC.Common/Database/Migrations/202210100826_AddPlayersTable.cs
@@ -1,6 +1,7 @@
 ﻿using EvoSC.Common.Database.Models.Player;
 using EvoSC.Common.Util;
 using FluentMigrator;
+using FluentMigrator.Postgres;
 
 namespace EvoSC.Common.Database.Migrations;
 
@@ -11,7 +12,7 @@ public class AddPlayersTable : Migration
     public override void Up()
     {
         Create.Table(DbPlayer.TableName)
-            .WithColumn("Id").AsInt32().PrimaryKey().Identity()
+            .WithColumn("Id").AsInt32().PrimaryKey().Identity(PostgresGenerationType.ByDefault)
             .WithColumn("AccountId").AsString().Unique()
             .WithColumn("UbisoftName").AsString().Indexed()
             .WithColumn("NickName").AsString()
@@ -28,6 +29,11 @@ public class AddPlayersTable : Migration
             UbisoftName = PlayerUtils.NadeoPlayer.UbisoftName,
             Zone = PlayerUtils.NadeoPlayer.Zone
         });
+
+        // Postgres identity sequences aren't advanced by explicit inserts, so the next
+        // auto-assigned player Id would collide with the seeded Nadeo row (Id = 1).
+        IfDatabase("Postgres").Execute.Sql(
+            "SELECT setval(pg_get_serial_sequence('\"Players\"', 'Id'), (SELECT MAX(\"Id\") FROM \"Players\"));");
     }
 
     public override void Down()

--- a/src/EvoSC.Common/Database/Repository/Players/PlayerRepository.cs
+++ b/src/EvoSC.Common/Database/Repository/Players/PlayerRepository.cs
@@ -22,6 +22,20 @@ public class PlayerRepository(IDbConnectionFactory dbConnFactory, IPermissionRep
             return null;
         }
 
+        if (player.DbSettings == null)
+        {
+            var playerSettings = new DbPlayerSettings
+            {
+                PlayerId = player.Id,
+                DisplayLanguage = "en",
+                HiddenManialinks = []
+            };
+
+            await Database.InsertAsync(playerSettings);
+
+            player.DbSettings = playerSettings;
+        }
+
         var groups = await permissionRepository.GetGroupsAsync(player.Id);
         player.Groups = groups;
 
@@ -55,11 +69,14 @@ public class PlayerRepository(IDbConnectionFactory dbConnFactory, IPermissionRep
 
         var playerSettings = new DbPlayerSettings
         {
-            PlayerId = player.Id, 
-            DisplayLanguage = "en"
+            PlayerId = player.Id,
+            DisplayLanguage = "en",
+            HiddenManialinks = []
         };
 
         await Database.InsertAsync(playerSettings);
+
+        player.DbSettings = playerSettings;
 
         return player;
     }

--- a/src/EvoSC.Common/EvoSC.Common.csproj
+++ b/src/EvoSC.Common/EvoSC.Common.csproj
@@ -19,7 +19,7 @@
       <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
       <PackageReference Include="GBX.NET" Version="1.2.6" />
       <PackageReference Include="GBX.NET.LZO" Version="1.0.4" />
-      <PackageReference Include="GbxRemote.Net" Version="5.0.3" />
+      <PackageReference Include="GbxRemote.Net" Version="5.0.7" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="linq2db" Version="5.3.2" />
       <PackageReference Include="linq2db.MySql" Version="5.3.2" />

--- a/src/EvoSC.Common/Logging/EvoScConsoleFormatter.cs
+++ b/src/EvoSC.Common/Logging/EvoScConsoleFormatter.cs
@@ -27,11 +27,10 @@ public class EvoScConsoleFormatter : ConsoleFormatter
             return;
         }
 
-        var timestamp = DateTime.Now.ToString("dd.MM.yyyy HH:mm:ss.fff");
+        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffK");
 
-        textWriter.Write('[');
         textWriter.Write(timestamp);
-        textWriter.Write("] ");
+        textWriter.Write(" ");
 
         textWriter.Write(GetLevelColor(logEntry.LogLevel));
         textWriter.Write(GetLevelText(logEntry.LogLevel));

--- a/src/EvoSC.Common/Logging/EvoScConsoleFormatter.cs
+++ b/src/EvoSC.Common/Logging/EvoScConsoleFormatter.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace EvoSC.Common.Logging;
+
+/// <summary>
+/// Console formatter that prints the log level as an uppercase word, e.g. "DEBUG some message".
+/// </summary>
+public class EvoScConsoleFormatter : ConsoleFormatter
+{
+    public const string FormatterName = "evosc";
+
+    private const string AnsiReset = "\x1B[0m";
+
+    public EvoScConsoleFormatter() : base(FormatterName)
+    {
+    }
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider,
+        TextWriter textWriter)
+    {
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+
+        if (string.IsNullOrEmpty(message) && logEntry.Exception is null)
+        {
+            return;
+        }
+
+        var timestamp = DateTime.Now.ToString("dd.MM.yyyy HH:mm:ss.fff");
+
+        textWriter.Write('[');
+        textWriter.Write(timestamp);
+        textWriter.Write("] ");
+
+        textWriter.Write(GetLevelColor(logEntry.LogLevel));
+        textWriter.Write(GetLevelText(logEntry.LogLevel));
+        textWriter.Write(AnsiReset);
+
+        textWriter.Write(' ');
+        textWriter.Write(logEntry.Category);
+        textWriter.Write(": ");
+        textWriter.Write(message);
+
+        if (logEntry.Exception is not null)
+        {
+            textWriter.Write(' ');
+            textWriter.Write(logEntry.Exception);
+        }
+
+        textWriter.Write(Environment.NewLine);
+    }
+
+    private static string GetLevelText(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "TRACE",
+        LogLevel.Debug => "DEBUG",
+        LogLevel.Information => "INFO",
+        LogLevel.Warning => "WARN",
+        LogLevel.Error => "ERROR",
+        LogLevel.Critical => "CRIT",
+        _ => "NONE"
+    };
+
+    private static string GetLevelColor(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "\x1B[90m",
+        LogLevel.Debug => "\x1B[90m",
+        LogLevel.Information => "\x1B[32m",
+        LogLevel.Warning => "\x1B[33m",
+        LogLevel.Error => "\x1B[31m",
+        LogLevel.Critical => "\x1B[1m\x1B[31m",
+        _ => AnsiReset
+    };
+}

--- a/src/EvoSC.Common/Logging/LoggingServiceExtensions.cs
+++ b/src/EvoSC.Common/Logging/LoggingServiceExtensions.cs
@@ -27,7 +27,7 @@ public static class LoggingServiceExtensions
                 builder.AddJsonConsole(o =>
                 {
                     o.IncludeScopes = true;
-                    o.TimestampFormat = "dd.MM.yyyy HH:mm:ss.fff";
+                    o.TimestampFormat = "yyyy-MM-ddTHH:mm:ss.fffK";
                     o.UseUtcTimestamp = true;
                 });
             }
@@ -40,7 +40,7 @@ public static class LoggingServiceExtensions
 
         services.RegisterInstance<ILoggerFactory>(loggerFactory);
         services.RegisterSingleton(typeof(ILogger<>), typeof(Logger<>));
-        
+
         return services;
     }
 
@@ -62,7 +62,7 @@ public static class LoggingServiceExtensions
                 builder.AddJsonConsole(o =>
                 {
                     o.IncludeScopes = true;
-                    o.TimestampFormat = "dd.MM.yyyy HH:mm:ss.fff";
+                    o.TimestampFormat = "yyyy-MM-ddTHH:mm:ss.fffK";
                     o.UseUtcTimestamp = true;
                 });
             }

--- a/src/EvoSC.Common/Logging/LoggingServiceExtensions.cs
+++ b/src/EvoSC.Common/Logging/LoggingServiceExtensions.cs
@@ -27,18 +27,14 @@ public static class LoggingServiceExtensions
                 builder.AddJsonConsole(o =>
                 {
                     o.IncludeScopes = true;
-                    o.TimestampFormat = "dd.MM.yyyy hh:mm:ss.ffff";
+                    o.TimestampFormat = "dd.MM.yyyy HH:mm:ss.fff";
                     o.UseUtcTimestamp = true;
                 });
             }
             else
             {
-                builder.AddSimpleConsole(c =>
-                {
-                    c.ColorBehavior = LoggerColorBehavior.Enabled;
-                    c.SingleLine = true;
-                    c.TimestampFormat = "[dd.MM.yyyy hh:mm:ss.ffff] ";
-                });
+                builder.AddConsole(o => o.FormatterName = EvoScConsoleFormatter.FormatterName)
+                    .AddConsoleFormatter<EvoScConsoleFormatter, ConsoleFormatterOptions>();
             }
         });
 
@@ -66,18 +62,14 @@ public static class LoggingServiceExtensions
                 builder.AddJsonConsole(o =>
                 {
                     o.IncludeScopes = true;
-                    o.TimestampFormat = "dd.MM.yyyy hh:mm:ss.ffff";
+                    o.TimestampFormat = "dd.MM.yyyy HH:mm:ss.fff";
                     o.UseUtcTimestamp = true;
                 });
             }
             else
             {
-                builder.AddSimpleConsole(c =>
-                {
-                    c.ColorBehavior = LoggerColorBehavior.Enabled;
-                    c.SingleLine = true;
-                    c.TimestampFormat = "[dd.MM.yyyy hh:mm:ss.ffff] ";
-                });
+                builder.AddConsole(o => o.FormatterName = EvoScConsoleFormatter.FormatterName)
+                    .AddConsoleFormatter<EvoScConsoleFormatter, ConsoleFormatterOptions>();
             }
         });
     }

--- a/src/EvoSC.Common/Remote/ServerClient.cs
+++ b/src/EvoSC.Common/Remote/ServerClient.cs
@@ -64,6 +64,7 @@ public partial class ServerClient : IServerClient
 
         await _gbxRemote.SetApiVersionAsync(GbxRemoteClient.DefaultApiVersion);
         await _gbxRemote.EnableCallbackTypeAsync();
+        await _gbxRemote.TriggerModeScriptEventArrayAsync("Trackmania.Event.SetCurRaceCheckpointsMode", "always");
         await _gbxRemote.SendHideManialinkPageAsync(); //hide all manialinks on connect
         await _gbxRemote.ChatEnableManualRoutingAsync();
 

--- a/src/EvoSC.Common/Services/MatchSettingsService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsService.cs
@@ -69,7 +69,15 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
 
             if (skipMap)
             {
-                await server.Remote.JumpToMapIndexAsync(0);
+                try 
+                {
+                    await server.Remote.JumpToMapIndexAsync(0);
+                } 
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to jump to map index 0, trying to restart map", name);
+                    await server.Remote.RestartMapAsync();
+                }
             }
         }
         catch (XmlRpcFaultException ex)

--- a/src/EvoSC.Common/Services/MatchSettingsService.cs
+++ b/src/EvoSC.Common/Services/MatchSettingsService.cs
@@ -69,7 +69,7 @@ public class MatchSettingsService(ILogger<MatchSettingsService> logger, IServerC
 
             if (skipMap)
             {
-                await server.Remote.NextMapAsync();
+                await server.Remote.JumpToMapIndexAsync(0);
             }
         }
         catch (XmlRpcFaultException ex)

--- a/src/EvoSC.Common/Util/PlayerUtils.cs
+++ b/src/EvoSC.Common/Util/PlayerUtils.cs
@@ -222,8 +222,6 @@ public static class PlayerUtils
     /// <param name="player"></param>
     /// <param name="templateName"></param>
     /// <returns></returns>
-    public static bool ManialinkIsHidden(this IPlayer player, string templateName)
-    {
-        return player.Settings.HiddenManialinks.Contains(templateName);
-    }
+    public static bool ManialinkIsHidden(this IPlayer player, string templateName) =>
+        player.Settings?.HiddenManialinks?.Contains(templateName) ?? false;
 }

--- a/src/Modules/ASayModule/Controllers/ASayController.cs
+++ b/src/Modules/ASayModule/Controllers/ASayController.cs
@@ -1,5 +1,5 @@
-﻿using EvoSC.Commands;
-using EvoSC.Commands.Attributes;
+﻿using EvoSC.Commands.Attributes;
+using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Modules.Official.ASayModule.Events;
@@ -8,7 +8,7 @@ using EvoSC.Modules.Official.ASayModule.Interfaces;
 namespace EvoSC.Modules.Official.ASayModule.Controllers;
 
 [Controller]
-public class ASayController(IASayService asayService) : EvoScController<CommandInteractionContext>
+public class ASayController(IASayService asayService) : EvoScController<ICommandInteractionContext>
 {
     [ChatCommand("asay", "Shows a message to all connected players as manialink.", ASayPermissions.UseASay, true)]
     public async Task ShowAnnounceMessageToPlayersAsync(string? text)

--- a/src/Modules/ASayModule/Controllers/ASayController.cs
+++ b/src/Modules/ASayModule/Controllers/ASayController.cs
@@ -28,9 +28,6 @@ public class ASayController(IASayService asayService) : EvoScController<CommandI
             Context.AuditEvent.Success()
                 .WithEventName(AuditEvents.ClearAnnouncement)
                 .Comment("Announcement was cleared.");
-            Context.AuditEvent.Success()
-                .WithEventName(AuditEvents.ClearAnnouncement)
-                .Comment("Announcement was cleared.");
         }
     }
     
@@ -38,5 +35,8 @@ public class ASayController(IASayService asayService) : EvoScController<CommandI
     public async Task ClearAnnouncementMessageForPlayersAsync()
     {
         await asayService.HideAnnouncementAsync();
+        Context.AuditEvent.Success()
+            .WithEventName(AuditEvents.ClearAnnouncement)
+            .Comment("Announcement was cleared.");
     }
 }

--- a/src/Modules/ASayModule/Services/ASayService.cs
+++ b/src/Modules/ASayModule/Services/ASayService.cs
@@ -7,26 +7,17 @@ using EvoSC.Modules.Official.ASayModule.Interfaces;
 
 namespace EvoSC.Modules.Official.ASayModule.Services;
 
-[Service(LifeStyle = ServiceLifeStyle.Scoped)]
-public class ASayService(IManialinkManager manialinkManager, IContextService context)
+[Service(LifeStyle = ServiceLifeStyle.Transient)]
+public class ASayService(IManialinkManager manialinkManager)
     : IASayService
 {
     public async Task ShowAnnouncementAsync(string text)
     {
         await manialinkManager.SendPersistentManialinkAsync("ASayModule.Announcement", new {text});
-        
-        context.Audit().Success()
-            .WithEventName(AuditEvents.ShowAnnouncement)
-            .HavingProperties(new {Text = text})
-            .Comment("Announcement was shown.");
     }
 
     public async Task HideAnnouncementAsync()
     {
         await manialinkManager.HideManialinkAsync("ASayModule.Announcement");
-        
-        context.Audit().Success()
-            .WithEventName(AuditEvents.ClearAnnouncement)
-            .Comment("Announcement was cleared.");
     }
 }

--- a/src/Modules/MapQueueModule/Controllers/QueueController.cs
+++ b/src/Modules/MapQueueModule/Controllers/QueueController.cs
@@ -21,6 +21,11 @@ public class QueueController(IMapQueueService mapQueue, IServerClient server, IM
     {
         var map = await maps.GetCurrentMapAsync();
 
+        if (map == null)
+        {
+            return;
+        }
+
         try
         {
             await mapQueue.DropAsync(map);

--- a/src/Modules/MapQueueModule/Services/MapQueueService.cs
+++ b/src/Modules/MapQueueModule/Services/MapQueueService.cs
@@ -39,6 +39,11 @@ public class MapQueueService(IEventManager events) : IMapQueueService
 
     public Task DropAsync(IMap map)
     {
+        if (_mapQueue.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
         var isNext = _mapQueue.PeekFirst() == map;
         _mapQueue.Drop(map);
         return events.RaiseAsync(MapQueueEvents.MapDropped, new MapQueueMapDroppedEventArgs

--- a/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
+++ b/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
@@ -47,7 +47,8 @@ public class MatchReadyEventController(
     public async Task OnMatchReadyEnabled(object sender, EnabledEventArgs args)
     {
         readyService.Enabled = true;
-        
+        await readyService.ResetAsync();
+
         await readyService.AddPlayersAsync(args.Players.ToArray());
         
         await readyManialinkService.SendWidgetAsync();
@@ -57,8 +58,9 @@ public class MatchReadyEventController(
     public async Task OnMatchReadyDisabled(object sender, EventArgs args)
     {
         readyService.Enabled = false;
+        await readyService.ResetAsync();
         
-        readyManialinkService.SendWidgetAsync();
+        await readyManialinkService.HideWidgetAsync();
     }
 
     [Subscribe(MatchReadyEvents.PlayerReadyChanged)]
@@ -73,5 +75,15 @@ public class MatchReadyEventController(
         );
         
         await readyManialinkService.UpdateWidgetAsync();
+    }
+
+    [Subscribe(GbxRemoteEvent.BeginMatch)]
+    public Task OnMatchStartedAsync(object sender, EventArgs args) => readyManialinkService.HideWidgetAsync();
+
+    [Subscribe(MatchReadyEvents.AllPlayersReady)]
+    public async Task OnAllPlayersReadyAsync(object sender, EventArgs args)
+    {
+        readyService.Enabled = false;
+        await readyManialinkService.HideWidgetAsync();
     }
 }

--- a/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
+++ b/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
@@ -44,10 +44,22 @@ public class MatchReadyEventController(
     }
 
     [Subscribe(MatchReadyEvents.Enabled)]
-    public Task OnMatchReadyEnabled(object sender, EventArgs args) => readyManialinkService.SendWidgetAsync();
-    
+    public async Task OnMatchReadyEnabled(object sender, EnabledEventArgs args)
+    {
+        readyService.Enabled = true;
+        
+        await readyService.AddPlayersAsync(args.Players.ToArray());
+        
+        await readyManialinkService.SendWidgetAsync();
+    }
+
     [Subscribe(MatchReadyEvents.Disabled)]
-    public Task OnMatchReadyDisabled(object sender, EventArgs args) => readyManialinkService.SendWidgetAsync();
+    public async Task OnMatchReadyDisabled(object sender, EventArgs args)
+    {
+        readyService.Enabled = false;
+        
+        readyManialinkService.SendWidgetAsync();
+    }
 
     [Subscribe(MatchReadyEvents.PlayerReadyChanged)]
     public async Task OnReadyChangedAsync(object sender, PlayerReadyEventArgs args)

--- a/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
+++ b/src/Modules/MatchReadyModule/Controllers/MatchReadyEventController.cs
@@ -83,7 +83,6 @@ public class MatchReadyEventController(
     [Subscribe(MatchReadyEvents.AllPlayersReady)]
     public async Task OnAllPlayersReadyAsync(object sender, EventArgs args)
     {
-        readyService.Enabled = false;
-        await readyManialinkService.HideWidgetAsync();
+        await readyService.DisableAsync();
     }
 }

--- a/src/Modules/MatchReadyModule/Controllers/ReadyCommandsController.cs
+++ b/src/Modules/MatchReadyModule/Controllers/ReadyCommandsController.cs
@@ -3,12 +3,20 @@ using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;
 using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Modules.Official.MatchReadyModule.Events;
+using EvoSC.Modules.Official.MatchReadyModule.Events.Args;
 using EvoSC.Modules.Official.MatchReadyModule.Interfaces;
 
 namespace EvoSC.Modules.Official.MatchReadyModule.Controllers;
 
 [Controller]
-public class ReadyCommandsController(IReadyService readyService, IServerClient server) : EvoScController<ICommandInteractionContext>
+public class ReadyCommandsController(
+    IReadyService readyService,
+    IServerClient server,
+    IPlayerManagerService players,
+    IEventManager events)
+    : EvoScController<ICommandInteractionContext>
 {
     [ChatCommand("ready", "Set yourself as ready for the match.")]
     [CommandAlias("/r")]
@@ -20,18 +28,29 @@ public class ReadyCommandsController(IReadyService readyService, IServerClient s
     [CommandAlias("/unrdy")]
     public Task SetUnreadyAsync() => readyService.SetPlayerReadyStatusAsync(Context.Player, false);
 
-    [ChatCommand("readytest", "Test the ready widget.")]
-    public async Task ReadyTestAsync()
-    {
-        await readyService.ResetAsync();
-        await readyService.AddPlayersAsync(Context.Player);
-        await readyService.EnableAsync();
-        /* await playerReady.ResetReadyWidgetAsync(true);
-        await playerReady.AddRequiredPlayers(Context.Player);
-        await playerReady.SetWidgetEnabled(true);
-        await playerReady.SendWidgetAsync(Context.Player); */
-    }
-
     [ChatCommand("readyfakeplayer", "Add a fake player with the ready widget.")]
     public Task ReadyFakePlayerAsync() => server.Remote.ConnectFakePlayerAsync();
+
+    [ChatCommand("readysimulateenable", "Dev testing: raise the MatchReady Enabled event with all currently connected players.")]
+    public async Task SimulateEnabledEventAsync()
+    {
+        var onlinePlayers = await players.GetOnlinePlayersAsync();
+
+        await events.RaiseAsync(MatchReadyEvents.Enabled, new EnabledEventArgs
+        {
+            Players = onlinePlayers
+        });
+    }
+
+    [ChatCommand("readysimulatedisable", "Dev testing: raise the MatchReady Disabled event.")]
+    public Task SimulateDisabledEventAsync() => events.RaiseAsync(MatchReadyEvents.Disabled, EventArgs.Empty);
+
+    [ChatCommand("readyforceall", "Dev testing: force all tracked players to be ready.")]
+    public async Task ForceAllReadyAsync()
+    {
+        foreach (var player in readyService.Players)
+        {
+            await readyService.SetPlayerReadyStatusAsync(player, true);
+        }
+    }
 }

--- a/src/Modules/MatchReadyModule/Events/Args/EnabledEventArgs.cs
+++ b/src/Modules/MatchReadyModule/Events/Args/EnabledEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using EvoSC.Common.Interfaces.Models;
+
+namespace EvoSC.Modules.Official.MatchReadyModule.Events.Args;
+
+public class EnabledEventArgs : EventArgs
+{
+    public required IEnumerable<IPlayer> Players { get; init; }
+}

--- a/src/Modules/MatchReadyModule/Events/MatchReadyEvents.cs
+++ b/src/Modules/MatchReadyModule/Events/MatchReadyEvents.cs
@@ -13,12 +13,12 @@ public enum MatchReadyEvents
     PlayerReadyChanged,
     
     /// <summary>
-    /// Raised when the ready widget and service enabled.
+    /// Raised when the ready widget and service are enabled.
     /// </summary>
     Enabled,
     
     /// <summary>
-    /// Raised when the ready widget and service enabled.
+    /// Raised when the ready widget and service are disabled.
     /// </summary>
     Disabled
 }

--- a/src/Modules/MatchReadyModule/Interfaces/IReadyManialinkService.cs
+++ b/src/Modules/MatchReadyModule/Interfaces/IReadyManialinkService.cs
@@ -22,4 +22,10 @@ public interface IReadyManialinkService
     /// </summary>
     /// <returns></returns>
     public Task UpdateWidgetAsync();
+
+    /// <summary>
+    /// Hide the widget for all players.
+    /// </summary>
+    /// <returns></returns>
+    public Task HideWidgetAsync();
 }

--- a/src/Modules/MatchReadyModule/Interfaces/IReadyService.cs
+++ b/src/Modules/MatchReadyModule/Interfaces/IReadyService.cs
@@ -17,7 +17,7 @@ public interface IReadyService
     /// <summary>
     /// Whether the ready widget and it's commands are enabled.
     /// </summary>
-    public bool Enabled { get; }
+    public bool Enabled { get; set; }
     
     /// <summary>
     /// Reset everything to the initial state.

--- a/src/Modules/MatchReadyModule/Interfaces/IReadyTrackerService.cs
+++ b/src/Modules/MatchReadyModule/Interfaces/IReadyTrackerService.cs
@@ -22,7 +22,7 @@ public interface IReadyTrackerService
     /// <summary>
     /// Whether the ready tracker is enabled or not.
     /// </summary>
-    public bool Enabled { get; }
+    public bool Enabled { get; set; }
     
     /// <summary>
     /// Add a player to the tracker.

--- a/src/Modules/MatchReadyModule/Services/ReadyManialinkService.cs
+++ b/src/Modules/MatchReadyModule/Services/ReadyManialinkService.cs
@@ -66,4 +66,6 @@ public class ReadyManialinkService(IReadyService readyService, IManialinkManager
         
         await trans.CommitAsync();
     }
+
+    public Task HideWidgetAsync() => manialinks.HideManialinkAsync("MatchReadyModule.ReadyWidget");
 }

--- a/src/Modules/MatchReadyModule/Services/ReadyService.cs
+++ b/src/Modules/MatchReadyModule/Services/ReadyService.cs
@@ -5,11 +5,12 @@ using EvoSC.Common.Services.Models;
 using EvoSC.Modules.Official.MatchReadyModule.Events;
 using EvoSC.Modules.Official.MatchReadyModule.Events.Args;
 using EvoSC.Modules.Official.MatchReadyModule.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Modules.Official.MatchReadyModule.Services;
 
 [Service(LifeStyle = ServiceLifeStyle.Transient)]
-public class ReadyService(IReadyTrackerService readyTracker, IEventManager events) : IReadyService
+public class ReadyService(IReadyTrackerService readyTracker, IEventManager events, ILogger<IReadyService> logger) : IReadyService
 {
     public IEnumerable<IPlayer> ReadyPlayers => readyTracker.ReadyPlayers;
     public IEnumerable<IPlayer> Players => readyTracker.Players;
@@ -48,6 +49,7 @@ public class ReadyService(IReadyTrackerService readyTracker, IEventManager event
 
         if (readyTracker.AllReady)
         {
+            logger.LogInformation("All players ready");
             await events.RaiseAsync(MatchReadyEvents.AllPlayersReady, EventArgs.Empty);
         }
     }

--- a/src/Modules/MatchReadyModule/Services/ReadyService.cs
+++ b/src/Modules/MatchReadyModule/Services/ReadyService.cs
@@ -13,7 +13,12 @@ public class ReadyService(IReadyTrackerService readyTracker, IEventManager event
 {
     public IEnumerable<IPlayer> ReadyPlayers => readyTracker.ReadyPlayers;
     public IEnumerable<IPlayer> Players => readyTracker.Players;
-    public bool Enabled => readyTracker.Enabled;
+    
+    public bool Enabled
+    {
+        get => readyTracker.Enabled;
+        set => readyTracker.Enabled = value;
+    }
     public Task ResetAsync() => readyTracker.ClearAsync();
 
     public async Task AddPlayersAsync(params IPlayer[] players)

--- a/src/Modules/MatchReadyModule/Services/ReadyTrackerService.cs
+++ b/src/Modules/MatchReadyModule/Services/ReadyTrackerService.cs
@@ -58,6 +58,13 @@ public class ReadyTrackerService : IReadyTrackerService
                 return _enabled;
             }
         }
+        set
+        {
+            lock (_mainLock)
+            {
+                _enabled = value;
+            }
+        }
     }
 
     public Task AddPlayerAsync(IPlayer player)

--- a/src/Modules/OpenPlanetModule/Localization.resx
+++ b/src/Modules/OpenPlanetModule/Localization.resx
@@ -37,7 +37,7 @@
     <value>The OpenPlanet configuration you are using is not allowed on this server! Forced into spectator.</value>
   </data>
   <data name="Explanations.SwitchSignatureMode" xml:space="preserve">
-    <value>In the Openplanet menu click $9dfDeveloper$g then $9dfSignature Mode$g.</value>
+    <value>In the Openplanet menu click $9dfOpenplanet$g then $9dfSignature Mode$g.</value>
   </data>
   <data name="Explanations.UpdateOpenPlanet" xml:space="preserve">
     <value>Go to the $L[https://openplanet.dev/download/next]$9dfOpenPlanet Download$L$g website and download the latest version.</value>

--- a/src/Modules/OpenPlanetModule/Models/OpenPlanetInfo.cs
+++ b/src/Modules/OpenPlanetModule/Models/OpenPlanetInfo.cs
@@ -7,7 +7,7 @@ namespace EvoSC.Modules.Official.OpenPlanetModule.Models;
 public class OpenPlanetInfo : IOpenPlanetInfo
 {
     private static readonly Regex OpenPlanetRegex =
-        new("^Openplanet ([\\d.]+) \\((\\w+), ([A-Z]\\w+), (\\d{4}-\\d{2}-\\d{2})\\)(?:\\s(?:\\[([A-Z]+)\\]))*$");
+        new("^Openplanet ([\\d.]+) \\((\\w+), ([A-Z]\\w+), (\\w+)\\)(?:\\s\\[([A-Z]+)\\])?$");
     
     public Version Version { get; set; }
     public string Game { get; set; }

--- a/src/Modules/OpenPlanetModule/Models/OpenPlanetInfo.cs
+++ b/src/Modules/OpenPlanetModule/Models/OpenPlanetInfo.cs
@@ -7,7 +7,7 @@ namespace EvoSC.Modules.Official.OpenPlanetModule.Models;
 public class OpenPlanetInfo : IOpenPlanetInfo
 {
     private static readonly Regex OpenPlanetRegex =
-        new("^Openplanet ([\\d.]+) \\((\\w+), ([A-Z]\\w+), (\\w+)\\)(?:\\s\\[([A-Z]+)\\])?$");
+        new("^Openplanet ([\\d.]+) \\(([^,]+), ([^,]+), ([^ )]+)\\)(?:\\s\\[([A-Z]+)\\])?$");
     
     public Version Version { get; set; }
     public string Game { get; set; }

--- a/src/Modules/OpenPlanetModule/Templates/WarningWindow.mt
+++ b/src/Modules/OpenPlanetModule/Templates/WarningWindow.mt
@@ -31,10 +31,10 @@
                 <label class="text" text="{{ Locale.PlayerLanguage.WarningMl_OpenPlanetRestricted }}" halign="center" pos="100 -24"/>
                 
                 <label class="text" text="{{ Locale.PlayerLanguage.WarningMl_ChoseSignatureMode }}" halign="center" pos="100 -32" if="Reason == OpJailReason.InvalidSignatureMode" />
-                <label class="text" textcolor="{{ Theme.OpenPlanetModule_WarningWindow_TextHighlight }}" text='{{ string.Join(", ", AllowedSignatures) }}' halign="center" pos="100 -36" if="Reason == OpJailReason.InvalidSignatureMode"/>
+                <label class="text" textcolor="{{ Theme.OpenPlanetModule_WarningWindow_TextHighlight }}" text='{{ string.Join(", ", AllowedSignatures) }}' halign="center" pos="100 -37" if="Reason == OpJailReason.InvalidSignatureMode"/>
 
                 <label class="text" text="{{ Locale.PlayerLanguage.WarningMl_MinimumVersionRequired }}" halign="center" pos="100 -32" if="Reason == OpJailReason.InvalidVersion" />
-                <label class="text" textcolor="{{ Theme.OpenPlanetModule_WarningWindow_TextHighlight }}" text='{{ Config.MinimumRequiredVersion }}' halign="center" pos="100 -36" if="Reason == OpJailReason.InvalidVersion"/>
+                <label class="text" textcolor="{{ Theme.OpenPlanetModule_WarningWindow_TextHighlight }}" text='{{ Config.MinimumRequiredVersion }}' halign="center" pos="100 -37" if="Reason == OpJailReason.InvalidVersion"/>
 
                 <label class="text" text="{{ Locale.PlayerLanguage.WarningMl_DisableOpenPlanet }}" halign="center" pos="100 -32" if="Reason == OpJailReason.OpenPlanetNotAllowed" />
                 
@@ -54,7 +54,7 @@
                 
                 <label class="text" text="$iYou will be automatically kicked in {{ Config.KickTimeout }} seconds." halign="center" pos="100 -73" id="countdownText" />
                 
-                <IconButton icon="{{ Icons.SignIn }}" text="Disconnect Now" hasText="true" width="30" y="-78" x="84" id="btnDisconnect" action="ManialinkActions/Disconnect" />
+                <IconButton icon="{{ Icons.SignIn }}" text="Disconnect Now" hasText="true" width="30" y="-79" x="84" id="btnDisconnect" action="ManialinkActions/Disconnect" />
             </frame>
         </Window>
     </template>

--- a/src/Modules/RoundRankingModule/Templates/Components/RoundRankingRow.mt
+++ b/src/Modules/RoundRankingModule/Templates/Components/RoundRankingRow.mt
@@ -21,7 +21,7 @@
             <quad
                     bgcolor="{{ Theme.UI_AccentSecondary }}"
                     size="{{ height }} {{ height }}"
-                    opacity="{{ Theme.UI_LocalRecordsModule_Widget_Row_Bg_Opacity }}"
+                    opacity="{{ Theme.UI_RoundRankingModule_Widget_Row_Bg_Opacity }}"
                     pos="0.7 0"
             />
             <label

--- a/src/Modules/RoundRankingModule/Templates/Components/RoundRankingStyles.mt
+++ b/src/Modules/RoundRankingModule/Templates/Components/RoundRankingStyles.mt
@@ -7,12 +7,12 @@
             <style
                     class="lr-body-primary"
                     bgcolor="{{ Theme.UI_RoundRankingModule_Widget_Row_Bg }}"
-                    opacity="{{ Theme.UI_LocalRecordsModule_Widget_Row_Bg_Opacity }}"
+                    opacity="{{ Theme.UI_RoundRankingModule_Widget_Row_Bg_Opacity }}"
             />
             <style
                     class="lr-body-highlight"
                     bgcolor="{{ Theme.UI_RoundRankingModule_Widget_Row_Bg_Highlight }}"
-                    opacity="{{ Theme.UI_LocalRecordsModule_Widget_Row_Bg_Opacity }}"
+                    opacity="{{ Theme.UI_RoundRankingModule_Widget_Row_Bg_Opacity }}"
             />
         </stylesheet>
     </template>

--- a/tests/Modules/ASayModule.Tests/ASayControllerTest.cs
+++ b/tests/Modules/ASayModule.Tests/ASayControllerTest.cs
@@ -1,3 +1,4 @@
+using EvoSC.Common.Interfaces.Models;
 using EvoSC.Modules.Official.ASayModule.Controllers;
 using EvoSC.Modules.Official.ASayModule.Interfaces;
 using EvoSC.Testing.Controllers;
@@ -7,19 +8,19 @@ namespace EvoSC.Modules.Official.ASayModule.Tests;
 
 public class ASayControllerTest : CommandInteractionControllerTestBase<ASayController>
 {
-    private readonly ASayController _controller;
+    private readonly Mock<IOnlinePlayer> _actor = new();
     private readonly Mock<IASayService> _service = new();
-    
+
     public ASayControllerTest()
     {
-        _controller = new ASayController(_service.Object);
+        InitMock(_actor.Object, _service);
     }
 
     [Fact]
     private async void Should_Show_Announcement_Message()
     {
         var text = "example message";
-        await _controller.ShowAnnounceMessageToPlayersAsync(text);
+        await Controller.ShowAnnounceMessageToPlayersAsync(text);
         _service.Verify(service => service.ShowAnnouncementAsync(text));
     }
 
@@ -27,14 +28,14 @@ public class ASayControllerTest : CommandInteractionControllerTestBase<ASayContr
     private async void Should_Clear_Announcement_Message_With_Empty_Param()
     {
         var empty = string.Empty;
-        await _controller.ShowAnnounceMessageToPlayersAsync(empty);
+        await Controller.ShowAnnounceMessageToPlayersAsync(empty);
         _service.Verify(service => service.HideAnnouncementAsync());
     }
 
     [Fact]
     private async void Should_Clear_Announcement_Message()
     {
-        await _controller.ClearAnnouncementMessageForPlayersAsync();
+        await Controller.ClearAnnouncementMessageForPlayersAsync();
         _service.Verify(service => service.HideAnnouncementAsync());
     }
 }

--- a/tests/Modules/ASayModule.Tests/ASayServiceTest.cs
+++ b/tests/Modules/ASayModule.Tests/ASayServiceTest.cs
@@ -72,10 +72,9 @@ public class ASayServiceTest
     private async void Should_Show_Announcement_Message()
     {
         var mock = NewASayServiceMock();
-        
+
         var text = "example message";
         await mock.ASayService.ShowAnnouncementAsync(text);
-        mock.Audit.Verify(m=>m.Success(), Times.Once());
         _manialinkManager.Verify(manager => manager.SendPersistentManialinkAsync("ASayModule.Announcement", It.Is<object>(o => text.Equals(o.GetType().GetProperty("text")!.GetValue(o)))));
     }
 
@@ -84,7 +83,6 @@ public class ASayServiceTest
     {
         var mock = NewASayServiceMock();
         await mock.ASayService.HideAnnouncementAsync();
-        mock.Audit.Verify(m => m.Success(), Times.Once());
         _manialinkManager.Verify(manager => manager.HideManialinkAsync("ASayModule.Announcement"));
     }
 }

--- a/tests/Modules/ASayModule.Tests/ASayServiceTest.cs
+++ b/tests/Modules/ASayModule.Tests/ASayServiceTest.cs
@@ -51,7 +51,7 @@ public class ASayServiceTest
 
         var server = Mocking.NewServerClientMock();
 
-        var aSayService = new ASayService(_manialinkManager.Object, contextService.Object);
+        var aSayService = new ASayService(_manialinkManager.Object);
 
         var player = new Mock<IOnlinePlayer>();
         player.Setup(m => m.AccountId).Returns(PlayerAccountId);

--- a/tests/Modules/MatchReadyModule.Tests/MatchReadyEventControllerTests.cs
+++ b/tests/Modules/MatchReadyModule.Tests/MatchReadyEventControllerTests.cs
@@ -1,6 +1,5 @@
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Services;
-using EvoSC.Modules.Official.MatchManagerModule.Interfaces;
 using EvoSC.Modules.Official.MatchReadyModule.Controllers;
 using EvoSC.Modules.Official.MatchReadyModule.Interfaces;
 using EvoSC.Testing;
@@ -15,23 +14,12 @@ public class MatchReadyEventControllerTests : EventControllerTestBase<MatchReady
     private readonly Mock<IReadyService> _readyService = new();
     private readonly Mock<IPlayerManagerService> _players = new();
     private readonly Mock<IReadyManialinkService> _readyManialinkService = new();
-    private readonly Mock<IMatchControlService> _matchControl = new();
     private readonly Mock<ILogger<MatchReadyEventController>> _logger = new();
     private readonly (Mock<IServerClient> Server, Mock<GbxRemoteNet.Interfaces.IGbxRemoteClient> Remote, Mock<IChatService> Chat) _server = Mocking.NewServerClientMock();
 
     public MatchReadyEventControllerTests()
     {
-        InitMock(_readyService, _players, _readyManialinkService, _matchControl, _logger, _server.Server);
-    }
-
-    [Fact]
-    public async Task AllPlayersReady_Starts_The_Match_When_Enabled()
-    {
-        _readyService.SetupGet(s => s.Enabled).Returns(true);
-
-        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
-
-        _matchControl.Verify(m => m.StartMatchAsync(), Times.Once);
+        InitMock(_readyService, _players, _readyManialinkService, _logger, _server.Server);
     }
 
     [Fact]
@@ -42,27 +30,5 @@ public class MatchReadyEventControllerTests : EventControllerTestBase<MatchReady
         await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
 
         _readyService.Verify(s => s.DisableAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task AllPlayersReady_Does_Nothing_When_Not_Enabled()
-    {
-        _readyService.SetupGet(s => s.Enabled).Returns(false);
-
-        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
-
-        _matchControl.Verify(m => m.StartMatchAsync(), Times.Never);
-        _readyService.Verify(s => s.DisableAsync(), Times.Never);
-    }
-
-    [Fact]
-    public async Task AllPlayersReady_Does_Not_Disable_When_Starting_The_Match_Fails()
-    {
-        _readyService.SetupGet(s => s.Enabled).Returns(true);
-        _matchControl.Setup(m => m.StartMatchAsync()).ThrowsAsync(new InvalidOperationException());
-
-        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
-
-        _readyService.Verify(s => s.DisableAsync(), Times.Never);
     }
 }

--- a/tests/Modules/MatchReadyModule.Tests/MatchReadyEventControllerTests.cs
+++ b/tests/Modules/MatchReadyModule.Tests/MatchReadyEventControllerTests.cs
@@ -1,0 +1,68 @@
+using EvoSC.Common.Interfaces;
+using EvoSC.Common.Interfaces.Services;
+using EvoSC.Modules.Official.MatchManagerModule.Interfaces;
+using EvoSC.Modules.Official.MatchReadyModule.Controllers;
+using EvoSC.Modules.Official.MatchReadyModule.Interfaces;
+using EvoSC.Testing;
+using EvoSC.Testing.Controllers;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace MatchReadyModule.Tests;
+
+public class MatchReadyEventControllerTests : EventControllerTestBase<MatchReadyEventController>
+{
+    private readonly Mock<IReadyService> _readyService = new();
+    private readonly Mock<IPlayerManagerService> _players = new();
+    private readonly Mock<IReadyManialinkService> _readyManialinkService = new();
+    private readonly Mock<IMatchControlService> _matchControl = new();
+    private readonly Mock<ILogger<MatchReadyEventController>> _logger = new();
+    private readonly (Mock<IServerClient> Server, Mock<GbxRemoteNet.Interfaces.IGbxRemoteClient> Remote, Mock<IChatService> Chat) _server = Mocking.NewServerClientMock();
+
+    public MatchReadyEventControllerTests()
+    {
+        InitMock(_readyService, _players, _readyManialinkService, _matchControl, _logger, _server.Server);
+    }
+
+    [Fact]
+    public async Task AllPlayersReady_Starts_The_Match_When_Enabled()
+    {
+        _readyService.SetupGet(s => s.Enabled).Returns(true);
+
+        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
+
+        _matchControl.Verify(m => m.StartMatchAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task AllPlayersReady_Disables_The_Ready_Service_After_Starting_The_Match()
+    {
+        _readyService.SetupGet(s => s.Enabled).Returns(true);
+
+        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
+
+        _readyService.Verify(s => s.DisableAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task AllPlayersReady_Does_Nothing_When_Not_Enabled()
+    {
+        _readyService.SetupGet(s => s.Enabled).Returns(false);
+
+        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
+
+        _matchControl.Verify(m => m.StartMatchAsync(), Times.Never);
+        _readyService.Verify(s => s.DisableAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AllPlayersReady_Does_Not_Disable_When_Starting_The_Match_Fails()
+    {
+        _readyService.SetupGet(s => s.Enabled).Returns(true);
+        _matchControl.Setup(m => m.StartMatchAsync()).ThrowsAsync(new InvalidOperationException());
+
+        await Controller.OnAllPlayersReadyAsync(new object(), EventArgs.Empty);
+
+        _readyService.Verify(s => s.DisableAsync(), Times.Never);
+    }
+}

--- a/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
+++ b/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
@@ -14,14 +14,16 @@ public class ReadyServiceTests
         IReadyService ReadyService,
         Mock<IEventManager> EventManagerMock,
         Mock<IReadyTrackerService> TrackerServiceMock
+        Mock<ILogger<IReadyService>> LoggerMock
         ) NewServiceMock()
     {
         var eventManagerMock = new Mock<IEventManager>();
         var readyTrackerMock = new Mock<IReadyTrackerService>();
+        var loggerMock = new Mock<ILogger<IReadyService>>();
         
-        var service = new ReadyService(readyTrackerMock.Object, eventManagerMock.Object);
+        var service = new ReadyService(readyTrackerMock.Object, eventManagerMock.Object, loggerMock.Object);
         
-        return (service, eventManagerMock, readyTrackerMock);
+        return (service, eventManagerMock, readyTrackerMock, loggerMock);
     }
 
     [Fact]

--- a/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
+++ b/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
@@ -4,6 +4,7 @@ using EvoSC.Modules.Official.MatchReadyModule.Events;
 using EvoSC.Modules.Official.MatchReadyModule.Events.Args;
 using EvoSC.Modules.Official.MatchReadyModule.Interfaces;
 using EvoSC.Modules.Official.MatchReadyModule.Services;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace MatchReadyModule.Tests;

--- a/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
+++ b/tests/Modules/MatchReadyModule.Tests/ReadyServiceTests.cs
@@ -13,7 +13,7 @@ public class ReadyServiceTests
     private (
         IReadyService ReadyService,
         Mock<IEventManager> EventManagerMock,
-        Mock<IReadyTrackerService> TrackerServiceMock
+        Mock<IReadyTrackerService> TrackerServiceMock,
         Mock<ILogger<IReadyService>> LoggerMock
         ) NewServiceMock()
     {

--- a/tests/Modules/OpenPlanetModule.Tests/Models/OpenPlanetInfoTests.cs
+++ b/tests/Modules/OpenPlanetModule.Tests/Models/OpenPlanetInfoTests.cs
@@ -19,6 +19,21 @@ public class OpenPlanetInfoTests
         Assert.Equal("1234-56-78", opInfo.Build);
         Assert.Equal(OpenPlanetSignatureMode.Official, opInfo.SignatureMode);
     }
+    
+    [Fact]
+    public void No_Signature_ToolInfo_Is_Parsed_Correctly()
+    {
+        var expectedVersion = new Version(12, 34, 56);
+        var toolInfo = "Openplanet 12.34.56 (next, Public, 1234-56-78)";
+        var opInfo = OpenPlanetInfo.Parse(toolInfo);
+        
+        Assert.True(opInfo.IsOpenPlanet);
+        Assert.Equal(expectedVersion, opInfo.Version);
+        Assert.Equal("next", opInfo.Game);
+        Assert.Equal("Public", opInfo.Branch);
+        Assert.Equal("1234-56-78", opInfo.Build);
+        Assert.Equal(OpenPlanetSignatureMode.Regular, opInfo.SignatureMode);
+    }
 
     [Fact]
     public void Non_Openplanet_Toolinfo_Returns_Default_And_No_Openplanet_Flag_Set()


### PR DESCRIPTION
This is the first in a series of pull requests that aim to bring this project towards a more generally usable state and close some of the issues.

Commits below contain cherry-picked changes from the private XPEvo EvoSC-Sharp version, minus proprietary stuff.
Credit to the original authors is pointed out below.

## What's included (22 commits)

**Bug fixes**
- OpenPlanet detection regex fix + no-signature test (`eecbf01`) — @MRegterschot
- OpenPlanet localization/UI positioning (`f500200`) — @MRegterschot
- RoundRanking opacity theme-key fix (`644d720`) — @MRegterschot
- MapQueue null/empty-queue guards — fixes #334 (`477a561`) — @MRegterschot
- Postgres players-table identity collision fix (`5f52b2a`) — @AtomicLiquid
- Map index jump error handling with `RestartMapAsync` fallback (`3a36e1f`) — @MRegterschot
- Dockerfile `AS` casing (`06ad5b3`) — @Chris92de

**Improvements**
- GbxRemote.Net `5.0.3` → `5.0.7`, `NextMapAsync` → `JumpToMapIndexAsync(0)` (`a42dbfd`) — @MRegterschot
- Ignored-commands support in `ChatCommandManager`/parser/middleware (`2ac5c00`) — @MRegterschot
- Console log-level formatter (`bc6ac82`) + ISO timestamps (`38057aa`) — @AtomicLiquid
- ASay: audit moved to controller, service made transient (`43d9824`) — @snixtho
- ASay `ICommandInteractionContext` refactor (`1393917`) — @MRegterschot
- `Trackmania.Event.SetCurRaceCheckpointsMode` trigger on connect (`864b511`) — @MRegterschot — ⚠️ forces checkpoint mode to `always`; please confirm no impact on non-race modes
- Default player settings seeding + null-safe `ManialinkIsHidden` (`8db3c3f`) — @MRegterschot

**MatchReady (selective) — @MRegterschot**
- Enable-state + player management refactor (`d87e0be`), reset functionality + dev-test commands + controller tests (`3269f36`), test-suite fix-ups (`ec6214e`, `0ae27e1`, `80355d8`)
- Prerequisite `HideWidgetAsync` on `ReadyManialinkService` (`f50b8e5`) — @AtomicLiquid, @MRegterschot
- `AllPlayersReady` aligned to upstream final state (`DisableAsync`, `b6b05c5`) — the intermediate match-control-service flow was skipped as it was reverted upstream

## Verification
- `dotnet build EvoSC.sln`: 0 errors
- Full `dotnet test`: all projects pass, 0 failures
- New/changed behavior covered by extended tests (OpenPlanet, MapQueue, MatchReady, ASay, ChatCommandManager)